### PR TITLE
Add conditional registration of environments in GetItHelper class

### DIFF
--- a/injectable/lib/src/get_it_helper.dart
+++ b/injectable/lib/src/get_it_helper.dart
@@ -13,15 +13,18 @@ class GetItHelper {
   final EnvironmentFilter _environmentFilter;
 
   /// creates a new instance of GetItHelper
-  GetItHelper(this.getIt, [this.environment, EnvironmentFilter environmentFilter])
+  GetItHelper(this.getIt,
+      [this.environment, EnvironmentFilter environmentFilter])
       : assert(getIt != null),
         assert(environmentFilter == null || environment == null),
         _environmentFilter = environmentFilter ?? NoEnvOrContains(environment) {
     // register current Environments as lazy singleton
-    getIt.registerLazySingleton<Set<String>>(
-      () => _environmentFilter.environments,
-      instanceName: kEnvironmentsName,
-    );
+    if (!getIt.isRegistered(instanceName: kEnvironmentsName)) {
+      getIt.registerLazySingleton<Set<String>>(
+        () => _environmentFilter.environments,
+        instanceName: kEnvironmentsName,
+      );
+    }
   }
 
   bool _canRegister(Set<String> registerFor) {


### PR DESCRIPTION
directly related to  #120 

For those using a modular architecture, it is possible to share a singular instance of `GetIt` to resolve dependencies across packages.  However the introduction of the `GetItHelper`  causes an error when attempting to share the same `GetIt` instance because it is unable to be shared and therefore Injectable attempts to register environment strings on each instantiation of `GetItHelper`.

This solution simply adds a conditional before registering environment strings to prevent multiple registration attempts.  