### PR TITLE
Correct typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ dependencies:
   # add injectable to your dependencies
   injectable:
   # add get_it
-  get_It:
+  get_it:
 
 dev_dependencies:
   # add the generator to your dev_dependencies


### PR DESCRIPTION
Just a small typo in README.md. Instead of `get_It:` should be `get_it:`.