### PR TITLE
Fix library and resolver unit tests

### DIFF
--- a/injectable_generator/test/code_builder/library_test.dart
+++ b/injectable_generator/test/code_builder/library_test.dart
@@ -13,7 +13,8 @@ void main() {
 // ignore_for_file: unnecessary_lambdas
 // ignore_for_file: lines_longer_than_80_chars
 /// initializes the registration of provided dependencies inside of [GetIt]
-GetIt(GetIt get, {String environment, EnvironmentFilter environmentFilter}) {
+GetIt init(GetIt get,
+    {String environment, EnvironmentFilter environmentFilter}) {
   final gh = GetItHelper(get, environment, environmentFilter);
   return get;
 }
@@ -32,7 +33,8 @@ GetIt(GetIt get, {String environment, EnvironmentFilter environmentFilter}) {
 // ignore_for_file: unnecessary_lambdas
 // ignore_for_file: lines_longer_than_80_chars
 /// initializes the registration of provided dependencies inside of [GetIt]
-GetIt(GetIt get, {String environment, EnvironmentFilter environmentFilter}) {
+GetIt init(GetIt get,
+    {String environment, EnvironmentFilter environmentFilter}) {
   final gh = GetItHelper(get, environment, environmentFilter);
   gh.factory<Demo>(() => Demo());
   return get;

--- a/injectable_generator/test/resolver/resolver_test.dart
+++ b/injectable_generator/test/resolver/resolver_test.dart
@@ -20,67 +20,80 @@ class MockTypeResolver extends ImportableTypeResolverImpl {
 }
 
 void main() async {
-  var resolvedInput = await resolveInput('test/resolver/samples/source.dart');
-  var dependencyResolver = DependencyResolver(MockTypeResolver());
+  group('Dependency Resolver', () {
+    ResolvedInput? resolvedInput;
+    DependencyResolver? dependencyResolver;
 
-  test('Simple Factory no dependencies', () {
-    var simpleFactoryType = resolvedInput.library.findType('SimpleFactory')!;
+    setUp(() async {
+      resolvedInput = await resolveInput('test/resolver/samples/source.dart');
+      dependencyResolver = DependencyResolver(MockTypeResolver());
+    });
 
-    final type = ImportableType(
-      name: 'SimpleFactory',
-      import: 'source.dart',
-    );
-    expect(
-      DependencyConfig(
-        type: type,
-        typeImpl: type,
-        injectableType: InjectableType.factory,
-      ),
-      equals(dependencyResolver.resolve(simpleFactoryType)),
-    );
-  });
+    test('Simple Factory no dependencies', () {
+      var simpleFactoryType = resolvedInput!.library.findType('SimpleFactory')!;
 
-  test('Factory with dependencies', () {
-    final FactoryWithDeps = resolvedInput.library.findType('FactoryWithDeps')!;
-    final type = ImportableType(
-      name: 'FactoryWithDeps',
-      import: 'source.dart',
-    );
+      final type = ImportableType(
+        name: 'SimpleFactory',
+        import: 'source.dart',
+      );
+      expect(
+        DependencyConfig(
+          type: type,
+          typeImpl: type,
+          injectableType: InjectableType.factory,
+        ),
+        equals(dependencyResolver!.resolve(simpleFactoryType)),
+      );
+    });
 
-    final dependencyType = ImportableType(
-      name: 'SimpleFactory',
-      import: 'source.dart',
-    );
-    expect(
-      DependencyConfig(type: type, typeImpl: type, injectableType: InjectableType.factory, dependencies: [
-        InjectedDependency(
-          type: dependencyType,
-          paramName: 'simpleFactory',
-        )
-      ]),
-      dependencyResolver.resolve(FactoryWithDeps),
-    );
-  });
+    test('Factory with dependencies', () {
+      final FactoryWithDeps =
+          resolvedInput!.library.findType('FactoryWithDeps')!;
+      final type = ImportableType(
+        name: 'FactoryWithDeps',
+        import: 'source.dart',
+      );
 
-  test('Simple Factory as abstract no dependencies', () {
-    var factoryAsAbstract = resolvedInput.library.findType('FactoryAsAbstract')!;
+      final dependencyType = ImportableType(
+        name: 'SimpleFactory',
+        import: 'source.dart',
+      );
+      expect(
+        DependencyConfig(
+            type: type,
+            typeImpl: type,
+            injectableType: InjectableType.factory,
+            dependencies: [
+              InjectedDependency(
+                type: dependencyType,
+                paramName: 'simpleFactory',
+              )
+            ]),
+        dependencyResolver!.resolve(FactoryWithDeps),
+      );
+    });
 
-    final type = ImportableType(
-      name: 'IFactory',
-      import: 'source.dart',
-    );
+    test('Simple Factory as abstract no dependencies', () {
+      var factoryAsAbstract =
+          resolvedInput!.library.findType('FactoryAsAbstract')!;
 
-    final typeImpl = ImportableType(
-      name: 'FactoryAsAbstract',
-      import: 'source.dart',
-    );
-    expect(
-      DependencyConfig(
-        type: type,
-        typeImpl: typeImpl,
-        injectableType: InjectableType.factory,
-      ),
-      equals(dependencyResolver.resolve(factoryAsAbstract)),
-    );
+      final type = ImportableType(
+        name: 'IFactory',
+        import: 'source.dart',
+      );
+
+      final typeImpl = ImportableType(
+        name: 'FactoryAsAbstract',
+        import: 'source.dart',
+      );
+      expect(
+        DependencyConfig(
+          type: type,
+          typeImpl: typeImpl,
+          injectableType: InjectableType.factory,
+        ),
+        equals(dependencyResolver!.resolve(factoryAsAbstract)),
+      );
+    });
   });
 }


### PR DESCRIPTION
### Problem:
I tried running `dart test` on master of this repo and 3 tests failed for me. The expectations in 2 of the `library_test.dart` tests don't include the method name, `init`, that will be generated. One of the tests in `resolver_test.dart` is failing because of test environment pollution between tests.

### Solution:
- Updated unit tests in `library_test.dart` to include expected method name, `init`.
- Updated test suite in `resolver_test.dart` to construct `resolvedInput` and `dependencyResolver` inside a `setUp` callback to ensure a new instance of each is used when each test is run.

### QA:
- [ ] Run `dart test`
- [ ] Verify all tests passed