### PR TITLE
Use getAsync for async injected dependencies

### DIFF
--- a/injectable_generator/lib/code_builder/library_builder.dart
+++ b/injectable_generator/lib/code_builder/library_builder.dart
@@ -12,410 +12,402 @@ const _injectableImport = 'package:injectable/injectable.dart';
 const _getItRefer = Reference('GetIt', 'package:get_it/get_it.dart');
 const _ghRefer = Reference('gh');
 
-Library generateLibrary({
-  required List<DependencyConfig> dependencies,
-  required String initializerName,
-  Uri? targetFile,
-  bool asExtension = false,
-}) {
-  final sorted = sortDependencies(dependencies);
+class LibraryGenerator {
+  late Set<DependencyConfig> _dependencies;
+  final String _initializerName;
+  final Uri? _targetFile;
+  final bool _asExtension;
 
-  // if true use an awaited initializer
-  final hasPreResolvedDeps = hasPreResolvedDependencies(sorted);
-
-  // eager singleton instances are registered at the end
-  final eagerDeps = <DependencyConfig>{};
-  final lazyDeps = <DependencyConfig>{};
-  // all environment keys used
-  final environments = <String>{};
-  // all register modules
-  final modules = <ModuleConfig>{};
-  sorted.forEach((dep) {
-    environments.addAll(dep.environments);
-
-    if (dep.injectableType == InjectableType.singleton) {
-      eagerDeps.add(dep);
-    } else {
-      lazyDeps.add(dep);
-    }
-    if (dep.moduleConfig != null) {
-      modules.add(dep.moduleConfig!);
-    }
-  });
-
-  final ignoreForFileComments = [
-    '// ignore_for_file: unnecessary_lambdas',
-    '// ignore_for_file: lines_longer_than_80_chars'
-  ];
-  final getInstanceRefer = refer(asExtension ? 'this' : 'get');
-  final intiMethod = Method(
-    (b) => b
-      ..docs.addAll([
-        if (!asExtension) ...ignoreForFileComments,
-        '/// initializes the registration of provided dependencies inside of [GetIt]'
-      ])
-      ..returns = hasPreResolvedDeps
-          ? TypeReference((b) => b
-            ..symbol = 'Future'
-            ..types.add(_getItRefer))
-          : _getItRefer
-      ..name = initializerName
-      ..modifier = hasPreResolvedDeps ? MethodModifier.async : null
-      ..requiredParameters.addAll([
-        if (!asExtension)
-          Parameter(
-            (b) => b
-              ..name = 'get'
-              ..type = _getItRefer,
-          )
-      ])
-      ..optionalParameters.addAll([
-        Parameter((b) => b
-          ..named = true
-          ..name = 'environment'
-          ..type = nullableRefer(
-            'String',
-            nullable: true,
-          )),
-        Parameter((b) => b
-          ..named = true
-          ..name = 'environmentFilter'
-          ..type = nullableRefer(
-            'EnvironmentFilter',
-            url: _injectableImport,
-            nullable: true,
-          ))
-      ])
-      ..body = Block(
-        (b) => b.statements.addAll([
-          refer('GetItHelper', _injectableImport)
-              .newInstance(
-                [
-                  getInstanceRefer,
-                  refer('environment'),
-                  refer('environmentFilter'),
-                ],
-              )
-              .assignFinal('gh')
-              .statement,
-          ...modules.map((module) => refer('_\$${module.type.name}')
-              .call([
-                if (moduleHasOverrides(
-                  sorted.where((e) => e.moduleConfig == module),
-                ))
-                  getInstanceRefer
-              ])
-              .assignFinal(toCamelCase(module.type.name))
-              .statement),
-          ...lazyDeps
-              .map((dep) => buildLazyRegisterFun(dep, sorted, targetFile)),
-          ...eagerDeps
-              .map((dep) => buildSingletonRegisterFun(dep, sorted, targetFile)),
-          getInstanceRefer.returned.statement,
-        ]),
-      ),
-  );
-
-  return Library(
-    (b) => b
-      ..body.addAll(
-        [
-          ...environments.map((env) => Field(
-                (b) => b
-                  ..name = '_$env'
-                  ..type = refer('String')
-                  ..assignment = literalString(env).code
-                  ..modifier = FieldModifier.constant,
-              )),
-
-          if (asExtension)
-            Extension(
-              (b) => b
-                ..docs.addAll([
-                  ...ignoreForFileComments,
-                  '/// an extension to register the provided dependencies inside of [GetIt]',
-                ])
-                ..name = 'GetItInjectableX'
-                ..on = _getItRefer
-                ..methods.add(intiMethod),
-            ),
-          if (!asExtension) intiMethod,
-          // build modules
-          ...modules.map(
-            (module) => _buildModule(
-              module,
-              sorted.where((e) => e.moduleConfig == module),
-              sorted,
-              targetFile,
-            ),
-          )
-        ],
-      ),
-  );
-}
-
-Class _buildModule(ModuleConfig module, Iterable<DependencyConfig> deps,
-    Set<DependencyConfig> allDeps,
-    [Uri? targetFile]) {
-  final abstractDeps = deps.where((d) => d.moduleConfig!.isAbstract);
-  return Class((clazz) {
-    clazz
-      ..name = '_\$${module.type.name}'
-      ..extend = typeRefer(module.type, targetFile);
-    // check weather we should have a getIt field inside of our module
-    if (moduleHasOverrides(abstractDeps)) {
-      clazz.fields.add(Field(
-        (b) => b
-          ..name = '_getIt'
-          ..type = _getItRefer
-          ..modifier = FieldModifier.final$,
-      ));
-      clazz.constructors.add(
-        Constructor(
-          (b) => b
-            ..requiredParameters.add(
-              Parameter(
-                (b) => b
-                  ..name = '_getIt'
-                  ..toThis = true,
-              ),
-            ),
-        ),
-      );
-    }
-    clazz.methods.addAll(abstractDeps.map(
-      (dep) => Method(
-        (b) => b
-          ..annotations.add(refer('override'))
-          ..name = dep.moduleConfig!.initializerName
-          ..returns = typeRefer(dep.typeImpl, targetFile)
-          ..type = dep.moduleConfig!.isMethod ? null : MethodType.getter
-          ..body =
-              _buildInstance(dep, allDeps, targetFile, getReferName: '_getIt')
-                  .code,
-      ),
-    ));
-  });
-}
-
-Code buildLazyRegisterFun(
-  DependencyConfig dep,
-  Set<DependencyConfig> allDeps, [
-  Uri? targetFile,
-]) {
-  var funcReferName;
-  Map<String, Reference> factoryParams = {};
-  final hasAsyncDep = hasAsyncDependency(dep, allDeps);
-  final isOrHasAsyncDep = dep.isAsync || hasAsyncDep;
-
-  if (dep.injectableType == InjectableType.factory) {
-    final hasFactoryParams = dep.dependencies.any((d) => d.isFactoryParam);
-    if (hasFactoryParams) {
-      funcReferName = isOrHasAsyncDep ? 'factoryParamAsync' : 'factoryParam';
-      factoryParams.addAll(_resolveFactoryParams(dep, targetFile));
-    } else {
-      funcReferName = isOrHasAsyncDep ? 'factoryAsync' : 'factory';
-    }
-  } else if (dep.injectableType == InjectableType.lazySingleton) {
-    funcReferName = isOrHasAsyncDep ? 'lazySingletonAsync' : 'lazySingleton';
+  LibraryGenerator({
+    required List<DependencyConfig> dependencies,
+    required String initializerName,
+    Uri? targetFile,
+    bool asExtension = false,
+  })  : _initializerName = initializerName,
+        _targetFile = targetFile,
+        _asExtension = asExtension {
+    _dependencies = sortDependencies(dependencies);
   }
-  throwIf(funcReferName == null, 'Injectable type is not supported');
 
-  final registerExpression = _ghRefer.property(funcReferName).call([
-    Method(
+  Library generate() {
+    // if true use an awaited initializer
+    final hasPreResolvedDeps = hasPreResolvedDependencies(_dependencies);
+
+    // eager singleton instances are registered at the end
+    final eagerDeps = <DependencyConfig>{};
+    final lazyDeps = <DependencyConfig>{};
+    // all environment keys used
+    final environments = <String>{};
+    // all register modules
+    final modules = <ModuleConfig>{};
+    _dependencies.forEach((dep) {
+      environments.addAll(dep.environments);
+
+      if (dep.injectableType == InjectableType.singleton) {
+        eagerDeps.add(dep);
+      } else {
+        lazyDeps.add(dep);
+      }
+      if (dep.moduleConfig != null) {
+        modules.add(dep.moduleConfig!);
+      }
+    });
+
+    final ignoreForFileComments = [
+      '// ignore_for_file: unnecessary_lambdas',
+      '// ignore_for_file: lines_longer_than_80_chars'
+    ];
+    final getInstanceRefer = refer(_asExtension ? 'this' : 'get');
+    final intiMethod = Method(
       (b) => b
-        ..lambda = true
-        ..modifier = hasAsyncDep ? MethodModifier.async : null
-        ..requiredParameters.addAll(
-          factoryParams.keys.map(
-            (name) => Parameter((b) => b.name = name),
+        ..docs.addAll([
+          if (!_asExtension) ...ignoreForFileComments,
+          '/// initializes the registration of provided dependencies inside of [GetIt]'
+        ])
+        ..returns = hasPreResolvedDeps
+            ? TypeReference((b) => b
+              ..symbol = 'Future'
+              ..types.add(_getItRefer))
+            : _getItRefer
+        ..name = _initializerName
+        ..modifier = hasPreResolvedDeps ? MethodModifier.async : null
+        ..requiredParameters.addAll([
+          if (!_asExtension)
+            Parameter(
+              (b) => b
+                ..name = 'get'
+                ..type = _getItRefer,
+            )
+        ])
+        ..optionalParameters.addAll([
+          Parameter((b) => b
+            ..named = true
+            ..name = 'environment'
+            ..type = nullableRefer(
+              'String',
+              nullable: true,
+            )),
+          Parameter((b) => b
+            ..named = true
+            ..name = 'environmentFilter'
+            ..type = nullableRefer(
+              'EnvironmentFilter',
+              url: _injectableImport,
+              nullable: true,
+            ))
+        ])
+        ..body = Block(
+          (b) => b.statements.addAll([
+            refer('GetItHelper', _injectableImport)
+                .newInstance(
+                  [
+                    getInstanceRefer,
+                    refer('environment'),
+                    refer('environmentFilter'),
+                  ],
+                )
+                .assignFinal('gh')
+                .statement,
+            ...modules.map((module) => refer('_\$${module.type.name}')
+                .call([
+                  if (moduleHasOverrides(
+                    _dependencies.where((e) => e.moduleConfig == module),
+                  ))
+                    getInstanceRefer
+                ])
+                .assignFinal(toCamelCase(module.type.name))
+                .statement),
+            ...lazyDeps.map((dep) => buildLazyRegisterFun(dep)),
+            ...eagerDeps.map((dep) => buildSingletonRegisterFun(dep)),
+            getInstanceRefer.returned.statement,
+          ]),
+        ),
+    );
+
+    return Library(
+      (b) => b
+        ..body.addAll(
+          [
+            ...environments.map((env) => Field(
+                  (b) => b
+                    ..name = '_$env'
+                    ..type = refer('String')
+                    ..assignment = literalString(env).code
+                    ..modifier = FieldModifier.constant,
+                )),
+
+            if (_asExtension)
+              Extension(
+                (b) => b
+                  ..docs.addAll([
+                    ...ignoreForFileComments,
+                    '/// an extension to register the provided dependencies inside of [GetIt]',
+                  ])
+                  ..name = 'GetItInjectableX'
+                  ..on = _getItRefer
+                  ..methods.add(intiMethod),
+              ),
+            if (!_asExtension) intiMethod,
+            // build modules
+            ...modules.map(
+              (module) => _buildModule(
+                module,
+                _dependencies.where((e) => e.moduleConfig == module),
+              ),
+            )
+          ],
+        ),
+    );
+  }
+
+  Class _buildModule(ModuleConfig module, Iterable<DependencyConfig> deps) {
+    final abstractDeps = deps.where((d) => d.moduleConfig!.isAbstract);
+    return Class((clazz) {
+      clazz
+        ..name = '_\$${module.type.name}'
+        ..extend = typeRefer(module.type, _targetFile);
+      // check weather we should have a getIt field inside of our module
+      if (moduleHasOverrides(abstractDeps)) {
+        clazz.fields.add(Field(
+          (b) => b
+            ..name = '_getIt'
+            ..type = _getItRefer
+            ..modifier = FieldModifier.final$,
+        ));
+        clazz.constructors.add(
+          Constructor(
+            (b) => b
+              ..requiredParameters.add(
+                Parameter(
+                  (b) => b
+                    ..name = '_getIt'
+                    ..toThis = true,
+                ),
+              ),
           ),
-        )
-        ..body = dep.isFromModule
-            ? _buildInstanceForModule(dep, allDeps, targetFile).code
-            : _buildInstance(dep, allDeps, targetFile).code,
-    ).closure
-  ], {
-    if (dep.instanceName != null)
-      'instanceName': literalString(dep.instanceName!),
-    if (dep.environments.isNotEmpty == true)
-      'registerFor': literalSet(
-        dep.environments.map((e) => refer('_$e')),
-      ),
-    if (dep.preResolve == true) 'preResolve': literalBool(true),
-    if (dep.disposeFunction != null)
-      'dispose': _getDisposeFunctionAssignment(
-        dep.disposeFunction!,
-        targetFile,
-      )
-  }, [
-    typeRefer(dep.type, targetFile),
-    ...factoryParams.values.map((p) => p.type)
-  ]);
-  return dep.preResolve
-      ? registerExpression.awaited.statement
-      : registerExpression.statement;
-}
-
-Map<String, Reference> _resolveFactoryParams(DependencyConfig dep,
-    [Uri? targetFile]) {
-  final params = <String, Reference>{};
-  dep.dependencies.where((d) => d.isFactoryParam).forEach((d) {
-    params[d.paramName] = typeRefer(d.type, targetFile);
-  });
-  if (params.length < 2) {
-    params['_'] = refer('dynamic');
-  }
-  return params;
-}
-
-Code buildSingletonRegisterFun(
-  DependencyConfig dep,
-  Set<DependencyConfig> allDeps, [
-  Uri? targetFile,
-]) {
-  var funcReferName;
-  var asFactory = true;
-  final hasAsyncDep = hasAsyncDependency(dep, allDeps);
-  if (dep.isAsync || hasAsyncDep) {
-    funcReferName = 'singletonAsync';
-  } else if (dep.dependsOn.isNotEmpty) {
-    funcReferName = 'singletonWithDependencies';
-  } else {
-    asFactory = false;
-    funcReferName = 'singleton';
+        );
+      }
+      clazz.methods.addAll(abstractDeps.map(
+        (dep) => Method(
+          (b) => b
+            ..annotations.add(refer('override'))
+            ..name = dep.moduleConfig!.initializerName
+            ..returns = typeRefer(dep.typeImpl, _targetFile)
+            ..type = dep.moduleConfig!.isMethod ? null : MethodType.getter
+            ..body = _buildInstance(dep,
+                    getAsyncMethodName: '_getIt.getAsync',
+                    getMethodName: '_getIt')
+                .code,
+        ),
+      ));
+    });
   }
 
-  final instanceBuilder = dep.isFromModule
-      ? _buildInstanceForModule(dep, allDeps, targetFile)
-      : _buildInstance(dep, allDeps, targetFile);
-  final registerExpression = _ghRefer.property(funcReferName).call([
-    asFactory
-        ? Method((b) => b
+  Code buildLazyRegisterFun(DependencyConfig dep) {
+    var funcReferName;
+    Map<String, Reference> factoryParams = {};
+    final hasAsyncDep = hasAsyncDependency(dep, _dependencies);
+    final isOrHasAsyncDep = dep.isAsync || hasAsyncDep;
+
+    if (dep.injectableType == InjectableType.factory) {
+      final hasFactoryParams = dep.dependencies.any((d) => d.isFactoryParam);
+      if (hasFactoryParams) {
+        funcReferName = isOrHasAsyncDep ? 'factoryParamAsync' : 'factoryParam';
+        factoryParams.addAll(_resolveFactoryParams(dep));
+      } else {
+        funcReferName = isOrHasAsyncDep ? 'factoryAsync' : 'factory';
+      }
+    } else if (dep.injectableType == InjectableType.lazySingleton) {
+      funcReferName = isOrHasAsyncDep ? 'lazySingletonAsync' : 'lazySingleton';
+    }
+    throwIf(funcReferName == null, 'Injectable type is not supported');
+
+    final registerExpression = _ghRefer.property(funcReferName).call([
+      Method(
+        (b) => b
           ..lambda = true
           ..modifier = hasAsyncDep ? MethodModifier.async : null
-          ..body = instanceBuilder.code).closure
-        : instanceBuilder
-  ], {
-    if (dep.instanceName != null)
-      'instanceName': literalString(dep.instanceName!),
-    if (dep.dependsOn.isNotEmpty)
-      'dependsOn': literalList(
-        dep.dependsOn.map(
-          (e) => typeRefer(e, targetFile),
-        ),
-      ),
-    if (dep.environments.isNotEmpty)
-      'registerFor': literalSet(
-        dep.environments.map((e) => refer('_$e')),
-      ),
-    if (dep.signalsReady != null)
-      'signalsReady': literalBool(dep.signalsReady!),
-    if (dep.preResolve == true) 'preResolve': literalBool(true),
-    if (dep.disposeFunction != null)
-      'dispose': _getDisposeFunctionAssignment(
-        dep.disposeFunction!,
-        targetFile,
-      )
-  }, [
-    typeRefer(dep.type, targetFile)
-  ]);
-
-  return dep.preResolve
-      ? registerExpression.awaited.statement
-      : registerExpression.statement;
-}
-
-Expression _buildInstance(
-  DependencyConfig dep,
-  Set<DependencyConfig> allDeps,
-  Uri? targetFile, {
-  String getReferName = 'get',
-}) {
-  final positionalParams = dep.positionalDependencies.map(
-    (iDep) =>
-        _buildParamAssignment(iDep, allDeps, targetFile, name: getReferName),
-  );
-
-  final namedParams = Map.fromEntries(
-    dep.namedDependencies.map(
-      (iDep) => MapEntry(
-        iDep.paramName,
-        _buildParamAssignment(iDep, allDeps, targetFile, name: getReferName),
-      ),
-    ),
-  );
-
-  final ref = typeRefer(dep.typeImpl, targetFile);
-  if (dep.constructorName?.isNotEmpty == true) {
-    return ref
-        .newInstanceNamed(
-          dep.constructorName!,
-          positionalParams,
-          namedParams,
-        )
-        .expression;
-  } else {
-    return ref.newInstance(positionalParams, namedParams).expression;
-  }
-}
-
-Expression _buildInstanceForModule(
-    DependencyConfig dep, Set<DependencyConfig> allDeps, Uri? targetFile) {
-  final module = dep.moduleConfig!;
-  if (!module.isMethod) {
-    return refer(
-      toCamelCase(module.type.name),
-    ).property(module.initializerName).expression;
-  }
-
-  return refer(toCamelCase(module.type.name))
-      .newInstanceNamed(
-        module.initializerName,
-        dep.positionalDependencies.map(
-          (iDep) =>
-              _buildParamAssignment(iDep, allDeps, targetFile, name: 'get'),
-        ),
-        Map.fromEntries(
-          dep.namedDependencies.map(
-            (iDep) => MapEntry(
-              iDep.paramName,
-              _buildParamAssignment(iDep, allDeps, targetFile, name: 'get'),
+          ..requiredParameters.addAll(
+            factoryParams.keys.map(
+              (name) => Parameter((b) => b.name = name),
             ),
+          )
+          ..body = dep.isFromModule
+              ? _buildInstanceForModule(dep).code
+              : _buildInstance(dep).code,
+      ).closure
+    ], {
+      if (dep.instanceName != null)
+        'instanceName': literalString(dep.instanceName!),
+      if (dep.environments.isNotEmpty == true)
+        'registerFor': literalSet(
+          dep.environments.map((e) => refer('_$e')),
+        ),
+      if (dep.preResolve == true) 'preResolve': literalBool(true),
+      if (dep.disposeFunction != null)
+        'dispose': _getDisposeFunctionAssignment(dep.disposeFunction!)
+    }, [
+      typeRefer(dep.type, _targetFile),
+      ...factoryParams.values.map((p) => p.type)
+    ]);
+    return dep.preResolve
+        ? registerExpression.awaited.statement
+        : registerExpression.statement;
+  }
+
+  Map<String, Reference> _resolveFactoryParams(DependencyConfig dep) {
+    final params = <String, Reference>{};
+    dep.dependencies.where((d) => d.isFactoryParam).forEach((d) {
+      params[d.paramName] = typeRefer(d.type, _targetFile);
+    });
+    if (params.length < 2) {
+      params['_'] = refer('dynamic');
+    }
+    return params;
+  }
+
+  Code buildSingletonRegisterFun(DependencyConfig dep) {
+    var funcReferName;
+    var asFactory = true;
+    final hasAsyncDep = hasAsyncDependency(dep, _dependencies);
+    if (dep.isAsync || hasAsyncDep) {
+      funcReferName = 'singletonAsync';
+    } else if (dep.dependsOn.isNotEmpty) {
+      funcReferName = 'singletonWithDependencies';
+    } else {
+      asFactory = false;
+      funcReferName = 'singleton';
+    }
+
+    final instanceBuilder =
+        dep.isFromModule ? _buildInstanceForModule(dep) : _buildInstance(dep);
+    final registerExpression = _ghRefer.property(funcReferName).call([
+      asFactory
+          ? Method((b) => b
+            ..lambda = true
+            ..modifier = hasAsyncDep ? MethodModifier.async : null
+            ..body = instanceBuilder.code).closure
+          : instanceBuilder
+    ], {
+      if (dep.instanceName != null)
+        'instanceName': literalString(dep.instanceName!),
+      if (dep.dependsOn.isNotEmpty)
+        'dependsOn': literalList(
+          dep.dependsOn.map(
+            (e) => typeRefer(e, _targetFile),
           ),
         ),
-      )
-      .expression;
-}
+      if (dep.environments.isNotEmpty)
+        'registerFor': literalSet(
+          dep.environments.map((e) => refer('_$e')),
+        ),
+      if (dep.signalsReady != null)
+        'signalsReady': literalBool(dep.signalsReady!),
+      if (dep.preResolve == true) 'preResolve': literalBool(true),
+      if (dep.disposeFunction != null)
+        'dispose': _getDisposeFunctionAssignment(dep.disposeFunction!)
+    }, [
+      typeRefer(dep.type, _targetFile)
+    ]);
 
-Expression _getDisposeFunctionAssignment(DisposeFunctionConfig disposeFunction,
-    [Uri? targetFile]) {
-  if (disposeFunction.isInstance) {
-    return Method((b) => b
-      ..requiredParameters.add(Parameter((b) => b.name = 'i'))
-      ..body = refer('i').property(disposeFunction.name).call([]).code).closure;
-  } else {
-    return typeRefer(disposeFunction.importableType!, targetFile);
+    return dep.preResolve
+        ? registerExpression.awaited.statement
+        : registerExpression.statement;
   }
-}
 
-Expression _buildParamAssignment(
-  InjectedDependency iDep,
-  Set<DependencyConfig> allDeps,
-  Uri? targetFile, {
-  required String name,
-}) {
-  if (iDep.isFactoryParam) {
-    return refer(iDep.paramName);
+  Expression _buildInstance(
+    DependencyConfig dep, {
+    String? getAsyncMethodName,
+    String? getMethodName,
+  }) {
+    final positionalParams = dep.positionalDependencies.map(
+      (iDep) => _buildParamAssignment(iDep,
+          getAsyncReferName: getAsyncMethodName, getReferName: getMethodName),
+    );
+
+    final namedParams = Map.fromEntries(
+      dep.namedDependencies.map(
+        (iDep) => MapEntry(
+          iDep.paramName,
+          _buildParamAssignment(iDep,
+              getAsyncReferName: getAsyncMethodName,
+              getReferName: getMethodName),
+        ),
+      ),
+    );
+
+    final ref = typeRefer(dep.typeImpl, _targetFile);
+    if (dep.constructorName?.isNotEmpty == true) {
+      return ref
+          .newInstanceNamed(
+            dep.constructorName!,
+            positionalParams,
+            namedParams,
+          )
+          .expression;
+    } else {
+      return ref.newInstance(positionalParams, namedParams).expression;
+    }
   }
-  final isAsync = isAsyncOrHasAsyncDependency(iDep, allDeps);
-  final expression = refer(isAsync ? '$name.getAsync' : name).call([], {
-    if (iDep.instanceName != null)
-      'instanceName': literalString(iDep.instanceName!),
-  }, [
-    typeRefer(iDep.type, targetFile, false),
-  ]);
-  return isAsync ? expression.awaited : expression;
+
+  Expression _buildInstanceForModule(DependencyConfig dep) {
+    final module = dep.moduleConfig!;
+    if (!module.isMethod) {
+      return refer(
+        toCamelCase(module.type.name),
+      ).property(module.initializerName).expression;
+    }
+
+    return refer(toCamelCase(module.type.name))
+        .newInstanceNamed(
+          module.initializerName,
+          dep.positionalDependencies.map(
+            (iDep) => _buildParamAssignment(iDep),
+          ),
+          Map.fromEntries(
+            dep.namedDependencies.map(
+              (iDep) => MapEntry(
+                iDep.paramName,
+                _buildParamAssignment(iDep),
+              ),
+            ),
+          ),
+        )
+        .expression;
+  }
+
+  Expression _getDisposeFunctionAssignment(
+      DisposeFunctionConfig disposeFunction) {
+    if (disposeFunction.isInstance) {
+      return Method((b) => b
+            ..requiredParameters.add(Parameter((b) => b.name = 'i'))
+            ..body = refer('i').property(disposeFunction.name).call([]).code)
+          .closure;
+    } else {
+      return typeRefer(disposeFunction.importableType!, _targetFile);
+    }
+  }
+
+  Expression _buildParamAssignment(
+    InjectedDependency iDep, {
+    String? getAsyncReferName,
+    String? getReferName,
+  }) {
+    if (iDep.isFactoryParam) {
+      return refer(iDep.paramName);
+    }
+    getAsyncReferName ??= _asExtension ? 'getAsync' : 'get.getAsync';
+    getReferName ??= 'get';
+    final isAsync = isAsyncOrHasAsyncDependency(iDep, _dependencies);
+    final expression =
+        refer(isAsync ? getAsyncReferName : getReferName).call([], {
+      if (iDep.instanceName != null)
+        'instanceName': literalString(iDep.instanceName!),
+    }, [
+      typeRefer(iDep.type, _targetFile, false),
+    ]);
+    return isAsync ? expression.awaited : expression;
+  }
 }
 
 bool moduleHasOverrides(Iterable<DependencyConfig> deps) {

--- a/injectable_generator/lib/generators/injectable_config_generator.dart
+++ b/injectable_generator/lib/generators/injectable_config_generator.dart
@@ -54,12 +54,13 @@ class InjectableConfigGenerator extends GeneratorForAnnotation<InjectableInit> {
 
     _reportMissingDependencies(deps, ignoredTypes, targetFile);
     _validateDuplicateDependencies(deps);
-    final generatedLib = generateLibrary(
+    final generator = LibraryGenerator(
       dependencies: deps,
       targetFile: preferRelativeImports ? targetFile : null,
       initializerName: initializerName,
       asExtension: asExtension,
     );
+    final generatedLib = generator.generate();
     final emitter = DartEmitter(
       allocator: Allocator.simplePrefixing(),
       orderDirectives: true,

--- a/injectable_generator/test/code_builder/builder_utils_test.dart
+++ b/injectable_generator/test/code_builder/builder_utils_test.dart
@@ -1,0 +1,318 @@
+import 'package:injectable_generator/code_builder/builder_utils.dart';
+import 'package:injectable_generator/injectable_types.dart';
+import 'package:injectable_generator/models/dependency_config.dart';
+import 'package:injectable_generator/models/importable_type.dart';
+import 'package:injectable_generator/models/injected_dependency.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('hasAsyncDependency', () {
+    test('should return `false` when there are no dependencies', () {
+      final dep = DependencyConfig(
+        type: ImportableType(name: 'Demo'),
+        typeImpl: ImportableType(name: 'Demo'),
+        injectableType: InjectableType.factory,
+      );
+      final allDeps = {dep};
+      expect(hasAsyncDependency(dep, allDeps), isFalse);
+    });
+
+    test('should return `false` when all deps are not async', () {
+      final dep = DependencyConfig(
+        type: ImportableType(name: 'Demo'),
+        typeImpl: ImportableType(name: 'Demo'),
+        injectableType: InjectableType.factory,
+        dependencies: [
+          InjectedDependency(
+            type: ImportableType(name: 'Fizz'),
+            paramName: 'fizz',
+          )
+        ],
+      );
+      final allDeps = {
+        dep,
+        DependencyConfig(
+          type: ImportableType(name: 'Fizz'),
+          typeImpl: ImportableType(name: 'Fizz'),
+          injectableType: InjectableType.factory,
+        ),
+      };
+      expect(hasAsyncDependency(dep, allDeps), isFalse);
+    });
+
+    test('should return `false` for a missing dependency', () {
+      final dep = DependencyConfig(
+        type: ImportableType(name: 'Demo'),
+        typeImpl: ImportableType(name: 'Demo'),
+        injectableType: InjectableType.factory,
+        dependencies: [
+          InjectedDependency(
+            type: ImportableType(name: 'Fizz'),
+            paramName: 'fizz',
+          )
+        ],
+      );
+      final allDeps = <DependencyConfig>{dep};
+      expect(hasAsyncDependency(dep, allDeps), isFalse);
+    });
+
+    test('should return `true` when at least one dep is async', () {
+      final dep = DependencyConfig(
+        type: ImportableType(name: 'Demo'),
+        typeImpl: ImportableType(name: 'Demo'),
+        injectableType: InjectableType.factory,
+        dependencies: [
+          InjectedDependency(
+            type: ImportableType(name: 'Fizz'),
+            paramName: 'fizz',
+          ),
+          InjectedDependency(
+            type: ImportableType(name: 'Buzz'),
+            paramName: 'buzz',
+            instanceName: 'buzzImpl',
+          ),
+        ],
+      );
+      final allDeps = {
+        dep,
+        DependencyConfig(
+          type: ImportableType(name: 'Fizz'),
+          typeImpl: ImportableType(name: 'Fizz'),
+          injectableType: InjectableType.factory,
+          isAsync: true,
+        ),
+        DependencyConfig(
+          type: ImportableType(name: 'Buzz'),
+          typeImpl: ImportableType(name: 'Buzz'),
+          injectableType: InjectableType.factory,
+          instanceName: 'buzzImpl',
+        ),
+      };
+      expect(hasAsyncDependency(dep, allDeps), isTrue);
+    });
+
+    test('should return `true` when a named instance dep is async', () {
+      final dep = DependencyConfig(
+        type: ImportableType(name: 'Demo'),
+        typeImpl: ImportableType(name: 'Demo'),
+        injectableType: InjectableType.factory,
+        dependencies: [
+          InjectedDependency(
+            type: ImportableType(name: 'Fizz'),
+            paramName: 'fizz',
+          ),
+          InjectedDependency(
+            type: ImportableType(name: 'Buzz'),
+            paramName: 'buzz',
+            instanceName: 'buzzImpl',
+          ),
+        ],
+      );
+      final allDeps = {
+        dep,
+        DependencyConfig(
+          type: ImportableType(name: 'Fizz'),
+          typeImpl: ImportableType(name: 'Fizz'),
+          injectableType: InjectableType.factory,
+        ),
+        DependencyConfig(
+          type: ImportableType(name: 'Buzz'),
+          typeImpl: ImportableType(name: 'Buzz'),
+          injectableType: InjectableType.factory,
+          instanceName: 'buzzImpl',
+          isAsync: true,
+        ),
+      };
+      expect(hasAsyncDependency(dep, allDeps), isTrue);
+    });
+
+    test('should return `true` when a transitive dep is async', () {
+      final dep = DependencyConfig(
+        type: ImportableType(name: 'Demo'),
+        typeImpl: ImportableType(name: 'Demo'),
+        injectableType: InjectableType.factory,
+        dependencies: [
+          InjectedDependency(
+            type: ImportableType(name: 'Fizz'),
+            paramName: 'fizz',
+          ),
+        ],
+      );
+      final allDeps = {
+        dep,
+        DependencyConfig(
+            type: ImportableType(name: 'Fizz'),
+            typeImpl: ImportableType(name: 'Fizz'),
+            injectableType: InjectableType.factory,
+            dependencies: [
+              InjectedDependency(
+                type: ImportableType(name: 'Buzz'),
+                paramName: 'buzz',
+                instanceName: 'buzzImpl',
+              ),
+            ]),
+        DependencyConfig(
+          type: ImportableType(name: 'Buzz'),
+          typeImpl: ImportableType(name: 'Buzz'),
+          injectableType: InjectableType.factory,
+          instanceName: 'buzzImpl',
+          isAsync: true,
+        ),
+      };
+      expect(hasAsyncDependency(dep, allDeps), isTrue);
+    });
+  });
+
+  group('isAsyncOrHasAsyncDependency', () {
+    test('should return `false` when dep lookup misses', () {
+      final iDep = InjectedDependency(
+        type: ImportableType(name: 'Fizz'),
+        paramName: 'fizz',
+      );
+      final allDeps = <DependencyConfig>{};
+      expect(isAsyncOrHasAsyncDependency(iDep, allDeps), isFalse);
+    });
+
+    test('should return `false` when not async and no deps', () {
+      final iDep = InjectedDependency(
+        type: ImportableType(name: 'Fizz'),
+        paramName: 'fizz',
+      );
+      final dep = DependencyConfig(
+        type: ImportableType(name: 'Fizz'),
+        typeImpl: ImportableType(name: 'Fizz'),
+        injectableType: InjectableType.factory,
+        isAsync: false,
+      );
+      final allDeps = {dep};
+      expect(isAsyncOrHasAsyncDependency(iDep, allDeps), isFalse);
+    });
+
+    test('should return `true` when async', () {
+      final iDep = InjectedDependency(
+        type: ImportableType(name: 'Fizz'),
+        paramName: 'fizz',
+      );
+      final dep = DependencyConfig(
+        type: ImportableType(name: 'Fizz'),
+        typeImpl: ImportableType(name: 'Fizz'),
+        injectableType: InjectableType.factory,
+        isAsync: true,
+      );
+      final allDeps = {dep};
+      expect(isAsyncOrHasAsyncDependency(iDep, allDeps), isTrue);
+    });
+
+    test('should return `false` when not async and no async deps', () {
+      final iDep = InjectedDependency(
+        type: ImportableType(name: 'Fizz'),
+        paramName: 'fizz',
+      );
+      final dep = DependencyConfig(
+        type: ImportableType(name: 'Fizz'),
+        typeImpl: ImportableType(name: 'Fizz'),
+        injectableType: InjectableType.factory,
+        dependencies: [
+          InjectedDependency(
+            type: ImportableType(name: 'Buzz'),
+            paramName: 'buzz',
+          )
+        ],
+      );
+      final allDeps = {
+        dep,
+        DependencyConfig(
+          type: ImportableType(name: 'Buzz'),
+          typeImpl: ImportableType(name: 'Buzz'),
+          injectableType: InjectableType.factory,
+        )
+      };
+      expect(isAsyncOrHasAsyncDependency(iDep, allDeps), isFalse);
+    });
+
+    test('should return `true` when has an async deps', () {
+      final iDep = InjectedDependency(
+        type: ImportableType(name: 'Fizz'),
+        paramName: 'fizz',
+      );
+      final dep = DependencyConfig(
+        type: ImportableType(name: 'Fizz'),
+        typeImpl: ImportableType(name: 'Fizz'),
+        injectableType: InjectableType.factory,
+        dependencies: [
+          InjectedDependency(
+            type: ImportableType(name: 'Buzz'),
+            paramName: 'buzz',
+          )
+        ],
+      );
+      final allDeps = {
+        dep,
+        DependencyConfig(
+          type: ImportableType(name: 'Buzz'),
+          typeImpl: ImportableType(name: 'Buzz'),
+          injectableType: InjectableType.factory,
+          isAsync: true,
+        )
+      };
+      expect(isAsyncOrHasAsyncDependency(iDep, allDeps), isTrue);
+    });
+  });
+
+  group('lookupDependency', () {
+    test('should return `null` when dep is not found', () {
+      final iDep = InjectedDependency(
+        type: ImportableType(name: 'Fizz'),
+        paramName: 'fizz',
+      );
+      final allDeps = <DependencyConfig>{};
+      expect(lookupDependency(iDep, allDeps), isNull);
+    });
+
+    test('should find and return dep', () {
+      final iDep = InjectedDependency(
+        type: ImportableType(name: 'Fizz'),
+        paramName: 'fizz',
+      );
+      final dep = DependencyConfig(
+        type: ImportableType(name: 'Fizz'),
+        typeImpl: ImportableType(name: 'Fizz'),
+        injectableType: InjectableType.factory,
+      );
+      final allDeps = {dep};
+      expect(lookupDependency(iDep, allDeps), same(dep));
+    });
+
+    test('should return `null` when named dep is not found', () {
+      final iDep = InjectedDependency(
+        type: ImportableType(name: 'Fizz'),
+        paramName: 'fizz',
+        instanceName: 'fizzy',
+      );
+      final dep = DependencyConfig(
+        type: ImportableType(name: 'Fizz'),
+        typeImpl: ImportableType(name: 'Fizz'),
+        injectableType: InjectableType.factory,
+        instanceName: 'fizzBuzz',
+      );
+      final allDeps = {dep};
+      expect(lookupDependency(iDep, allDeps), isNull);
+    });
+
+    test('should find and return named dep', () {
+      final iDep = InjectedDependency(
+        type: ImportableType(name: 'Fizz'),
+        instanceName: 'fizzImpl',
+        paramName: 'fizz',
+      );
+      final dep = DependencyConfig(
+        type: ImportableType(name: 'Fizz'),
+        typeImpl: ImportableType(name: 'Fizz'),
+        injectableType: InjectableType.factory,
+        instanceName: 'fizzImpl',
+      );
+      final allDeps = {dep};
+      expect(lookupDependency(iDep, allDeps), same(dep));
+    });
+  });
+}

--- a/injectable_generator/test/code_builder/eager_singleton_test.dart
+++ b/injectable_generator/test/code_builder/eager_singleton_test.dart
@@ -114,7 +114,7 @@ void main() {
           )
         ],
       );
-      final allDeps = {
+      final allDeps = [
         dep,
         DependencyConfig(
           injectableType: InjectableType.factory,
@@ -122,7 +122,7 @@ void main() {
           typeImpl: ImportableType(name: 'Storage'),
           isAsync: true,
         ),
-      };
+      ];
       expect(generate(dep, allDeps: allDeps),
           'gh.singletonAsync<Demo>(() async  => Demo( await get.getAsync<Storage>()));');
     });
@@ -160,7 +160,7 @@ void main() {
           )
         ],
       );
-      final allDeps = {
+      final allDeps = [
         dep,
         DependencyConfig(
           injectableType: InjectableType.factory,
@@ -169,16 +169,17 @@ void main() {
           instanceName: 'storageImpl',
           isAsync: true,
         ),
-      };
+      ];
       expect(generate(dep, allDeps: allDeps),
           'gh.singletonAsync<Demo>(() async  => Demo(storage:  await get.getAsync<Storage>(instanceName: \'storageImpl\')));');
     });
   });
 }
 
-String generate(DependencyConfig input,
-    {Set<DependencyConfig> allDeps: const {}}) {
-  final statement = buildSingletonRegisterFun(input, allDeps);
+String generate(DependencyConfig input, {List<DependencyConfig>? allDeps}) {
+  final generator = LibraryGenerator(
+      dependencies: allDeps ?? [], initializerName: 'initGetIt');
+  final statement = generator.buildSingletonRegisterFun(input);
   final emitter = DartEmitter(
     allocator: Allocator.none,
     orderDirectives: true,

--- a/injectable_generator/test/code_builder/eager_singleton_test.dart
+++ b/injectable_generator/test/code_builder/eager_singleton_test.dart
@@ -59,7 +59,10 @@ void main() {
             type: ImportableType(name: 'Demo'),
             typeImpl: ImportableType(name: 'Demo'),
             isAsync: true,
-            dependsOn: [ImportableType(name: 'Storage'), ImportableType(name: 'LocalRepo')],
+            dependsOn: [
+              ImportableType(name: 'Storage'),
+              ImportableType(name: 'LocalRepo')
+            ],
           )),
           "gh.singletonAsync<Demo>(() => Demo(), dependsOn: [Storage, LocalRepo]);");
     });
@@ -71,7 +74,10 @@ void main() {
             type: ImportableType(name: 'Demo'),
             typeImpl: ImportableType(name: 'Demo'),
             isAsync: false,
-            dependsOn: [ImportableType(name: 'Storage'), ImportableType(name: 'LocalRepo')],
+            dependsOn: [
+              ImportableType(name: 'Storage'),
+              ImportableType(name: 'LocalRepo')
+            ],
           )),
           'gh.singletonWithDependencies<Demo>(() => Demo(), dependsOn: [Storage, LocalRepo]);');
     });
@@ -94,6 +100,33 @@ void main() {
           'gh.singleton<Demo>(Demo(get<Storage>()));');
     });
 
+    test("Singleton generator with async Positional dependencies", () {
+      final dep = DependencyConfig(
+        injectableType: InjectableType.singleton,
+        type: ImportableType(name: 'Demo'),
+        typeImpl: ImportableType(name: 'Demo'),
+        dependencies: [
+          InjectedDependency(
+            type: ImportableType(name: 'Storage'),
+            paramName: 'storage',
+            isFactoryParam: false,
+            isPositional: true,
+          )
+        ],
+      );
+      final allDeps = {
+        dep,
+        DependencyConfig(
+          injectableType: InjectableType.factory,
+          type: ImportableType(name: 'Storage'),
+          typeImpl: ImportableType(name: 'Storage'),
+          isAsync: true,
+        ),
+      };
+      expect(generate(dep, allDeps: allDeps),
+          'gh.singletonAsync<Demo>(() async  => Demo( await get.getAsync<Storage>()));');
+    });
+
     test("Singleton generator with named dependencies", () {
       expect(
           generate(DependencyConfig(
@@ -111,11 +144,41 @@ void main() {
           )),
           'gh.singleton<Demo>(Demo(storage: get<Storage>()));');
     });
+
+    test("Singleton generator with async named dependencies", () {
+      final dep = DependencyConfig(
+        injectableType: InjectableType.singleton,
+        type: ImportableType(name: 'Demo'),
+        typeImpl: ImportableType(name: 'Demo'),
+        dependencies: [
+          InjectedDependency(
+            type: ImportableType(name: 'Storage'),
+            paramName: 'storage',
+            isFactoryParam: false,
+            isPositional: false,
+            instanceName: 'storageImpl',
+          )
+        ],
+      );
+      final allDeps = {
+        dep,
+        DependencyConfig(
+          injectableType: InjectableType.factory,
+          type: ImportableType(name: 'Storage'),
+          typeImpl: ImportableType(name: 'Storage'),
+          instanceName: 'storageImpl',
+          isAsync: true,
+        ),
+      };
+      expect(generate(dep, allDeps: allDeps),
+          'gh.singletonAsync<Demo>(() async  => Demo(storage:  await get.getAsync<Storage>(instanceName: \'storageImpl\')));');
+    });
   });
 }
 
-String generate(DependencyConfig input) {
-  final statement = buildSingletonRegisterFun(input);
+String generate(DependencyConfig input,
+    {Set<DependencyConfig> allDeps: const {}}) {
+  final statement = buildSingletonRegisterFun(input, allDeps);
   final emitter = DartEmitter(
     allocator: Allocator.none,
     orderDirectives: true,

--- a/injectable_generator/test/code_builder/factory_param_test.dart
+++ b/injectable_generator/test/code_builder/factory_param_test.dart
@@ -97,11 +97,45 @@ void main() {
           )),
           'gh.factoryParam<Demo, String, dynamic>((url, _) => Demo(get<Storage>(), url));');
     });
+
+    test("One factory param with injected async dependencies test", () {
+      final dep = DependencyConfig(
+        injectableType: InjectableType.factory,
+        type: ImportableType(name: 'Demo'),
+        typeImpl: ImportableType(name: 'Demo'),
+        dependencies: [
+          InjectedDependency(
+            type: ImportableType(name: 'Storage'),
+            paramName: 'storage',
+            isFactoryParam: false,
+            isPositional: true,
+          ),
+          InjectedDependency(
+            type: ImportableType(name: 'String'),
+            paramName: 'url',
+            isFactoryParam: true,
+            isPositional: true,
+          )
+        ],
+      );
+      final allDeps = {
+        dep,
+        DependencyConfig(
+          injectableType: InjectableType.factory,
+          type: ImportableType(name: 'Storage'),
+          typeImpl: ImportableType(name: 'Storage'),
+          isAsync: true,
+        ),
+      };
+      expect(generate(dep, allDeps: allDeps),
+          'gh.factoryParamAsync<Demo, String, dynamic>((url, _) async  => Demo( await get.getAsync<Storage>(), url));');
+    });
   });
 }
 
-String generate(DependencyConfig input) {
-  final statement = buildLazyRegisterFun(input);
+String generate(DependencyConfig input,
+    {Set<DependencyConfig> allDeps = const {}}) {
+  final statement = buildLazyRegisterFun(input, allDeps);
   final emitter = DartEmitter(
     allocator: Allocator.none,
     orderDirectives: true,

--- a/injectable_generator/test/code_builder/factory_param_test.dart
+++ b/injectable_generator/test/code_builder/factory_param_test.dart
@@ -118,7 +118,7 @@ void main() {
           )
         ],
       );
-      final allDeps = {
+      final allDeps = [
         dep,
         DependencyConfig(
           injectableType: InjectableType.factory,
@@ -126,16 +126,17 @@ void main() {
           typeImpl: ImportableType(name: 'Storage'),
           isAsync: true,
         ),
-      };
+      ];
       expect(generate(dep, allDeps: allDeps),
           'gh.factoryParamAsync<Demo, String, dynamic>((url, _) async  => Demo( await get.getAsync<Storage>(), url));');
     });
   });
 }
 
-String generate(DependencyConfig input,
-    {Set<DependencyConfig> allDeps = const {}}) {
-  final statement = buildLazyRegisterFun(input, allDeps);
+String generate(DependencyConfig input, {List<DependencyConfig>? allDeps}) {
+  final generator = LibraryGenerator(
+      dependencies: allDeps ?? [], initializerName: 'initGetIt');
+  final statement = generator.buildLazyRegisterFun(input);
   final emitter = DartEmitter(
     allocator: Allocator.none,
     orderDirectives: true,

--- a/injectable_generator/test/code_builder/lazy_factory_test.dart
+++ b/injectable_generator/test/code_builder/lazy_factory_test.dart
@@ -31,6 +31,33 @@ void main() {
           'gh.lazySingleton<Demo>(() => Demo());');
     });
 
+    test("lazy singleton generator with async dependencies", () {
+      final dep = DependencyConfig(
+        injectableType: InjectableType.lazySingleton,
+        type: ImportableType(name: 'Demo'),
+        typeImpl: ImportableType(name: 'Demo'),
+        dependencies: [
+          InjectedDependency(
+            type: ImportableType(name: 'Storage'),
+            paramName: 'storage',
+            isFactoryParam: false,
+            isPositional: true,
+          )
+        ],
+      );
+      final allDeps = {
+        dep,
+        DependencyConfig(
+          injectableType: InjectableType.factory,
+          type: ImportableType(name: 'Storage'),
+          typeImpl: ImportableType(name: 'Storage'),
+          isAsync: true,
+        )
+      };
+      expect(generate(dep, allDeps: allDeps),
+          'gh.lazySingletonAsync<Demo>(() async  => Demo( await get.getAsync<Storage>()));');
+    });
+
     test("factory generator abstract type != implementation", () {
       expect(
           generate(DependencyConfig(
@@ -70,6 +97,33 @@ void main() {
           'gh.factory<Demo>(() => Demo(get<Storage>()));');
     });
 
+    test("factory generator with async positional dependencies", () {
+      final dep = DependencyConfig(
+        injectableType: InjectableType.factory,
+        type: ImportableType(name: 'Demo'),
+        typeImpl: ImportableType(name: 'Demo'),
+        dependencies: [
+          InjectedDependency(
+            type: ImportableType(name: 'Storage'),
+            paramName: 'storage',
+            isFactoryParam: false,
+            isPositional: true,
+          )
+        ],
+      );
+      final allDeps = {
+        dep,
+        DependencyConfig(
+          injectableType: InjectableType.factory,
+          type: ImportableType(name: 'Storage'),
+          typeImpl: ImportableType(name: 'Storage'),
+          isAsync: true,
+        )
+      };
+      expect(generate(dep, allDeps: allDeps),
+          'gh.factoryAsync<Demo>(() async  => Demo( await get.getAsync<Storage>()));');
+    });
+
     test("factory generator with named dependencies", () {
       expect(
           generate(DependencyConfig(
@@ -86,6 +140,34 @@ void main() {
             ],
           )),
           "gh.factory<Demo>(() => Demo(storage: get<Storage>(instanceName: 'storageImpl')));");
+    });
+
+    test("factory generator with async named dependencies", () {
+      final dep = DependencyConfig(
+        type: ImportableType(name: 'Demo'),
+        typeImpl: ImportableType(name: 'Demo'),
+        injectableType: InjectableType.factory,
+        dependencies: [
+          InjectedDependency(
+              type: ImportableType(name: 'Storage'),
+              paramName: 'storage',
+              isFactoryParam: false,
+              isPositional: false,
+              instanceName: 'storageImpl')
+        ],
+      );
+      final allDeps = {
+        dep,
+        DependencyConfig(
+          injectableType: InjectableType.factory,
+          type: ImportableType(name: 'Storage'),
+          typeImpl: ImportableType(name: 'Storage'),
+          instanceName: 'storageImpl',
+          isAsync: true,
+        )
+      };
+      expect(generate(dep, allDeps: allDeps),
+          "gh.factoryAsync<Demo>(() async  => Demo(storage:  await get.getAsync<Storage>(instanceName: 'storageImpl')));");
     });
 
     test("factory generator with parameterized type", () {
@@ -110,8 +192,9 @@ void main() {
   });
 }
 
-String generate(DependencyConfig input) {
-  final statement = buildLazyRegisterFun(input);
+String generate(DependencyConfig input,
+    {Set<DependencyConfig> allDeps = const {}}) {
+  final statement = buildLazyRegisterFun(input, allDeps);
   final emitter = DartEmitter(
     allocator: Allocator.none,
     orderDirectives: true,

--- a/injectable_generator/test/code_builder/lazy_factory_test.dart
+++ b/injectable_generator/test/code_builder/lazy_factory_test.dart
@@ -45,7 +45,7 @@ void main() {
           )
         ],
       );
-      final allDeps = {
+      final allDeps = [
         dep,
         DependencyConfig(
           injectableType: InjectableType.factory,
@@ -53,7 +53,7 @@ void main() {
           typeImpl: ImportableType(name: 'Storage'),
           isAsync: true,
         )
-      };
+      ];
       expect(generate(dep, allDeps: allDeps),
           'gh.lazySingletonAsync<Demo>(() async  => Demo( await get.getAsync<Storage>()));');
     });
@@ -111,7 +111,7 @@ void main() {
           )
         ],
       );
-      final allDeps = {
+      final allDeps = [
         dep,
         DependencyConfig(
           injectableType: InjectableType.factory,
@@ -119,7 +119,7 @@ void main() {
           typeImpl: ImportableType(name: 'Storage'),
           isAsync: true,
         )
-      };
+      ];
       expect(generate(dep, allDeps: allDeps),
           'gh.factoryAsync<Demo>(() async  => Demo( await get.getAsync<Storage>()));');
     });
@@ -156,7 +156,7 @@ void main() {
               instanceName: 'storageImpl')
         ],
       );
-      final allDeps = {
+      final allDeps = [
         dep,
         DependencyConfig(
           injectableType: InjectableType.factory,
@@ -164,8 +164,8 @@ void main() {
           typeImpl: ImportableType(name: 'Storage'),
           instanceName: 'storageImpl',
           isAsync: true,
-        )
-      };
+        ),
+      ];
       expect(generate(dep, allDeps: allDeps),
           "gh.factoryAsync<Demo>(() async  => Demo(storage:  await get.getAsync<Storage>(instanceName: 'storageImpl')));");
     });
@@ -192,9 +192,10 @@ void main() {
   });
 }
 
-String generate(DependencyConfig input,
-    {Set<DependencyConfig> allDeps = const {}}) {
-  final statement = buildLazyRegisterFun(input, allDeps);
+String generate(DependencyConfig input, {List<DependencyConfig>? allDeps}) {
+  final generator = LibraryGenerator(
+      dependencies: allDeps ?? [], initializerName: 'initGetIt');
+  final statement = generator.buildLazyRegisterFun(input);
   final emitter = DartEmitter(
     allocator: Allocator.none,
     orderDirectives: true,

--- a/injectable_generator/test/code_builder/library_test.dart
+++ b/injectable_generator/test/code_builder/library_test.dart
@@ -58,11 +58,11 @@ extension GetItInjectableX on GetIt {
 }
 
 String generate(List<DependencyConfig> input, {bool asExt = false}) {
-  final library = generateLibrary(
+  final library = LibraryGenerator(
     dependencies: input,
     initializerName: 'init',
     asExtension: asExt,
-  );
+  ).generate();
   final emitter = DartEmitter(
     allocator: Allocator.none,
     orderDirectives: true,


### PR DESCRIPTION
This is a proposed fix for: https://github.com/Milad-Akarie/injectable/issues/230

### Problem:
When registering an injectable that has one or more async dependencies, the async dependencies are retrieved using `get<Dep>` rather than `await getAsync<Dep>`. An example of this is outlined in the issue linked above. I figured I'd go ahead and submit a proposal for fixing the problem. If it seems reasonable, I'd be happy to update the README to reflect this updated behavior too!

### Solution:
I added some utility functions to 1) look up a `DependencyConfig` given an `InjectedDependency`; 2) determine if a `DependencyConfig` has any dependencies or transitive dependencies that are async; and 3) determine if an `InjectedDependency` is async or it has any dependencies or transitive dependencies that are async.

I updated the library builder to use the new utility functions to determine if a dependency of an injectable is async, or if it has a dependency or transitive dependency that is async, and if so it will use the `await getAsync<Dep>` form to retrieve the dependency. If a dependency can't be found, it falls back to assuming the dependency is not async.

To be honest, I'm somewhat new to this library so it is quite possible I've missed some edge cases in this PR. Let me know if there's something I've missed or there are other changes you'd like me to make!

### Testing:
I've added a number of unit tests to exercise the changes outlined above. These new unit tests should all pass.