### PR TITLE
Factory functions for singletons

### DIFF
--- a/injectable/lib/src/get_it_helper.dart
+++ b/injectable/lib/src/get_it_helper.dart
@@ -147,7 +147,7 @@ class GetItHelper {
   /// a conditional wrapper method for getIt.registerSingleton
   /// it only registers if [_canRegister] returns true
   void singleton<T extends Object>(
-    T instance, {
+    FactoryFunc<T> instance, {
     String? instanceName,
     bool? signalsReady,
     Set<String>? registerFor,
@@ -155,7 +155,7 @@ class GetItHelper {
   }) {
     if (_canRegister(registerFor)) {
       getIt.registerSingleton<T>(
-        instance,
+        instance(),
         instanceName: instanceName,
         signalsReady: signalsReady,
         dispose: dispose,
@@ -178,7 +178,7 @@ class GetItHelper {
       if (preResolve) {
         return factoryfunc().then(
           (instance) => singleton(
-            instance,
+            () => instance,
             instanceName: instanceName,
             signalsReady: signalsReady,
             dispose: dispose,

--- a/injectable_generator/lib/code_builder/library_builder.dart
+++ b/injectable_generator/lib/code_builder/library_builder.dart
@@ -264,26 +264,22 @@ class LibraryGenerator {
 
   Code buildSingletonRegisterFun(DependencyConfig dep) {
     var funcReferName;
-    var asFactory = true;
     final hasAsyncDep = hasAsyncDependency(dep, _dependencies);
     if (dep.isAsync || hasAsyncDep) {
       funcReferName = 'singletonAsync';
     } else if (dep.dependsOn.isNotEmpty) {
       funcReferName = 'singletonWithDependencies';
     } else {
-      asFactory = false;
       funcReferName = 'singleton';
     }
 
     final instanceBuilder =
         dep.isFromModule ? _buildInstanceForModule(dep) : _buildInstance(dep);
     final registerExpression = _ghRefer.property(funcReferName).call([
-      asFactory
-          ? Method((b) => b
-            ..lambda = true
-            ..modifier = hasAsyncDep ? MethodModifier.async : null
-            ..body = instanceBuilder.code).closure
-          : instanceBuilder
+      Method((b) => b
+        ..lambda = true
+        ..modifier = hasAsyncDep ? MethodModifier.async : null
+        ..body = instanceBuilder.code).closure
     ], {
       if (dep.instanceName != null)
         'instanceName': literalString(dep.instanceName!),

--- a/injectable_generator/test/code_builder/eager_singleton_test.dart
+++ b/injectable_generator/test/code_builder/eager_singleton_test.dart
@@ -15,7 +15,7 @@ void main() {
             type: ImportableType(name: 'Demo'),
             typeImpl: ImportableType(name: 'Demo'),
           )),
-          'gh.singleton<Demo>(Demo());');
+          'gh.singleton<Demo>(() => Demo());');
     });
 
     test("Singleton generator abstract", () {
@@ -25,7 +25,7 @@ void main() {
           type: ImportableType(name: 'AbstractType'),
           typeImpl: ImportableType(name: 'Demo'),
         )),
-        'gh.singleton<AbstractType>(Demo());',
+        'gh.singleton<AbstractType>(() => Demo());',
       );
     });
 
@@ -37,7 +37,7 @@ void main() {
           typeImpl: ImportableType(name: 'Demo'),
           instanceName: 'MyDemo',
         )),
-        "gh.singleton<Demo>(Demo(), instanceName: 'MyDemo');",
+        "gh.singleton<Demo>(() => Demo(), instanceName: 'MyDemo');",
       );
     });
 
@@ -91,7 +91,7 @@ void main() {
               )
             ],
           )),
-          'gh.singleton<Demo>(Demo(get<Storage>()));');
+          'gh.singleton<Demo>(() => Demo(get<Storage>()));');
     });
 
     test("Singleton generator with async Positional dependencies", () {
@@ -136,7 +136,7 @@ void main() {
               )
             ],
           )),
-          'gh.singleton<Demo>(Demo(storage: get<Storage>()));');
+          'gh.singleton<Demo>(() => Demo(storage: get<Storage>()));');
     });
 
     test("Singleton generator with async named dependencies", () {
@@ -194,7 +194,7 @@ void main() {
         ),
       ];
       expect(generate(dep, allDeps: allDeps),
-          'gh.singleton<Demo>(Demo(storage: get<Storage>(instanceName: \'storageImpl\')));');
+          'gh.singleton<Demo>(() => Demo(storage: get<Storage>(instanceName: \'storageImpl\')));');
     });
   });
 }


### PR DESCRIPTION
I recently tried to initialize some values using my singleton constructors and these values can only be initialized once. But because the generated code creates an instance of every singleton that is annotated with the `@singelton` annotation, the values were initialized multiple times.

This PR changes: Instead of creating an instance of every registered singleton, only instances of the singletons required for the current environment will be created. Probably fixes errors like  #210.