### PR TITLE
Sync injectable and injectable_generator with GetIt v7.2.0 to generate non-nullable @factoryParams

### DIFF
--- a/injectable/lib/src/get_it_helper.dart
+++ b/injectable/lib/src/get_it_helper.dart
@@ -71,7 +71,7 @@ class GetItHelper {
   /// a conditional wrapper method for getIt.registerFactoryParam
   /// it only registers if [_canRegister] returns true
   void factoryParam<T extends Object, P1, P2>(
-    FactoryFuncParam<T, P1?, P2?> factoryfunc, {
+    FactoryFuncParam<T, P1, P2> factoryfunc, {
     String? instanceName,
     Set<String>? registerFor,
   }) {
@@ -86,7 +86,7 @@ class GetItHelper {
   /// a conditional wrapper method for getIt.registerFactoryParamAsync
   /// it only registers if [_canRegister] returns true
   void factoryParamAsync<T extends Object, P1, P2>(
-    FactoryFuncParamAsync<T, P1?, P2?> factoryfunc, {
+    FactoryFuncParamAsync<T, P1, P2> factoryfunc, {
     String? instanceName,
     Set<String>? registerFor,
   }) {

--- a/injectable/lib/src/get_it_helper.dart
+++ b/injectable/lib/src/get_it_helper.dart
@@ -86,7 +86,7 @@ class GetItHelper {
   /// a conditional wrapper method for getIt.registerFactoryParamAsync
   /// it only registers if [_canRegister] returns true
   void factoryParamAsync<T extends Object, P1, P2>(
-    FactoryFuncParamAsync<T, P1, P2> factoryfunc, {
+    FactoryFuncParamAsync<T, P1?, P2?> factoryfunc, {
     String? instanceName,
     Set<String>? registerFor,
   }) {

--- a/injectable/pubspec.lock
+++ b/injectable/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   collection:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: get_it
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.1.3"
+    version: "7.2.0"
   meta:
     dependency: transitive
     description:

--- a/injectable/pubspec.yaml
+++ b/injectable/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  get_it: ">=7.0.0 <8.0.0"
+  get_it: ">=7.2.0 <8.0.0"
 
 dev_dependencies:
   pedantic: ^1.9.0

--- a/injectable_generator/lib/resolvers/dependency_resolver.dart
+++ b/injectable_generator/lib/resolvers/dependency_resolver.dart
@@ -241,6 +241,12 @@ class DependencyResolver {
           : _typeResolver.resolveType(param.type);
       final isFactoryParam = _factoryParamChecker.hasAnnotationOfExact(param);
 
+      throwIf(
+        isFactoryParam && !resolvedType.isNullable && _isAsync,
+        'Async factory params must be nullable',
+        element: param,
+      );
+
       _dependencies.add(InjectedDependency(
         type: resolvedType,
         instanceName: instanceName,

--- a/injectable_generator/lib/resolvers/dependency_resolver.dart
+++ b/injectable_generator/lib/resolvers/dependency_resolver.dart
@@ -241,12 +241,6 @@ class DependencyResolver {
           : _typeResolver.resolveType(param.type);
       final isFactoryParam = _factoryParamChecker.hasAnnotationOfExact(param);
 
-      throwIf(
-        isFactoryParam && !resolvedType.isNullable,
-        'Factory params must be nullable',
-        element: param,
-      );
-
       _dependencies.add(InjectedDependency(
         type: resolvedType,
         instanceName: instanceName,

--- a/injectable_generator/test/resolver/resolver_test.dart
+++ b/injectable_generator/test/resolver/resolver_test.dart
@@ -6,6 +6,7 @@ import 'package:injectable_generator/models/importable_type.dart';
 import 'package:injectable_generator/models/injected_dependency.dart';
 import 'package:injectable_generator/resolvers/dependency_resolver.dart';
 import 'package:injectable_generator/resolvers/importable_type_resolver.dart';
+import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
 import 'utils.dart';
@@ -46,33 +47,6 @@ void main() async {
       );
     });
 
-    test('Factory with dependencies', () {
-      final FactoryWithDeps =
-          resolvedInput!.library.findType('FactoryWithDeps')!;
-      final type = ImportableType(
-        name: 'FactoryWithDeps',
-        import: 'source.dart',
-      );
-
-      final dependencyType = ImportableType(
-        name: 'SimpleFactory',
-        import: 'source.dart',
-      );
-      expect(
-        DependencyConfig(
-            type: type,
-            typeImpl: type,
-            injectableType: InjectableType.factory,
-            dependencies: [
-              InjectedDependency(
-                type: dependencyType,
-                paramName: 'simpleFactory',
-              )
-            ]),
-        dependencyResolver!.resolve(FactoryWithDeps),
-      );
-    });
-
     test('Factory with nullable dependencies', () {
       final FactoryWithDeps =
           resolvedInput!.library.findType('FactoryWithNullableDeps')!;
@@ -101,6 +75,90 @@ void main() async {
       );
     });
 
+    test('Factory with dependencies', () {
+      final FactoryWithDeps =
+          resolvedInput!.library.findType('FactoryWithDeps')!;
+      final type = ImportableType(
+        name: 'FactoryWithDeps',
+        import: 'source.dart',
+      );
+
+      final dependencyType = ImportableType(
+        name: 'SimpleFactory',
+        import: 'source.dart',
+      );
+      expect(
+        DependencyConfig(
+            type: type,
+            typeImpl: type,
+            injectableType: InjectableType.factory,
+            dependencies: [
+              InjectedDependency(
+                type: dependencyType,
+                paramName: 'simpleFactory',
+              )
+            ]),
+        dependencyResolver!.resolve(FactoryWithDeps),
+      );
+    });
+
+    test('Factory with nullable factoryParams', () {
+      final FactoryWithDeps =
+          resolvedInput!.library.findType('FactoryWithNullableFactoryParams')!;
+      final type = ImportableType(
+        name: 'FactoryWithNullableFactoryParams',
+        import: 'source.dart',
+      );
+
+      final dependencyType = ImportableType(
+        name: 'SimpleFactory',
+        import: 'source.dart',
+        isNullable: true,
+      );
+      expect(
+        DependencyConfig(
+            type: type,
+            typeImpl: type,
+            injectableType: InjectableType.factory,
+            dependencies: [
+              InjectedDependency(
+                type: dependencyType,
+                paramName: 'simpleFactory',
+                isFactoryParam: true,
+              )
+            ]),
+        dependencyResolver!.resolve(FactoryWithDeps),
+      );
+    });
+
+    test('Factory with factoryParams', () {
+      final FactoryWithDeps =
+          resolvedInput!.library.findType('FactoryWithFactoryParams')!;
+      final type = ImportableType(
+        name: 'FactoryWithFactoryParams',
+        import: 'source.dart',
+      );
+
+      final dependencyType = ImportableType(
+        name: 'SimpleFactory',
+        import: 'source.dart',
+      );
+      expect(
+        DependencyConfig(
+            type: type,
+            typeImpl: type,
+            injectableType: InjectableType.factory,
+            dependencies: [
+              InjectedDependency(
+                type: dependencyType,
+                paramName: 'simpleFactory',
+                isFactoryParam: true,
+              )
+            ]),
+        dependencyResolver!.resolve(FactoryWithDeps),
+      );
+    });
+
     test('Simple Factory as abstract no dependencies', () {
       var factoryAsAbstract =
           resolvedInput!.library.findType('FactoryAsAbstract')!;
@@ -114,6 +172,37 @@ void main() async {
         name: 'FactoryAsAbstract',
         import: 'source.dart',
       );
+
+      test('Async factory with nullable dependencies', () {
+        final FactoryWithDeps =
+            resolvedInput!.library.findType('AsyncFactoryWithNullableDeps')!;
+        final type = ImportableType(
+          name: 'AsyncFactoryWithNullableDeps',
+          import: 'source.dart',
+        );
+
+        final dependencyType = ImportableType(
+          name: 'SimpleFactory',
+          import: 'source.dart',
+          isNullable: true,
+        );
+        expect(
+          DependencyConfig(
+              type: type,
+              typeImpl: type,
+              injectableType: InjectableType.factory,
+              dependencies: [
+                InjectedDependency(
+                  type: dependencyType,
+                  paramName: 'simpleFactory',
+                  isFactoryParam: true,
+                )
+              ],
+              isAsync: true,
+              constructorName: 'create'),
+          dependencyResolver!.resolve(FactoryWithDeps),
+        );
+      });
       expect(
         DependencyConfig(
           type: type,
@@ -124,35 +213,17 @@ void main() async {
       );
     });
 
-    test('Async factory with nullable dependencies', () {
+    test('Async factory with non nullable dependencies', () {
       final FactoryWithDeps =
-          resolvedInput!.library.findType('AsyncFactoryWithNullableDeps')!;
-      final type = ImportableType(
-        name: 'AsyncFactoryWithNullableDeps',
-        import: 'source.dart',
-      );
-
-      final dependencyType = ImportableType(
-        name: 'AsyncFactory',
-        import: 'source.dart',
-        isNullable: true,
-      );
-      expect(
-        DependencyConfig(
-            type: type,
-            typeImpl: type,
-            injectableType: InjectableType.factory,
-            dependencies: [
-              InjectedDependency(
-                type: dependencyType,
-                paramName: 'asyncFactory',
-                isFactoryParam: true,
-              )
-            ],
-            isAsync: true,
-            constructorName: 'create'),
-        dependencyResolver!.resolve(FactoryWithDeps),
-      );
+          resolvedInput!.library.findType('AsyncFactoryWithNonNullableDeps')!;
+      final errorMessage = 'Async factory params must be nullable';
+      var resultError;
+      try {
+        dependencyResolver!.resolve(FactoryWithDeps);
+      } catch (error) {
+        resultError = error as InvalidGenerationSourceError;
+      }
+      expect(resultError.message, errorMessage);
     });
   });
 }

--- a/injectable_generator/test/resolver/resolver_test.dart
+++ b/injectable_generator/test/resolver/resolver_test.dart
@@ -73,6 +73,34 @@ void main() async {
       );
     });
 
+    test('Factory with nullable dependencies', () {
+      final FactoryWithDeps =
+          resolvedInput!.library.findType('FactoryWithNullableDeps')!;
+      final type = ImportableType(
+        name: 'FactoryWithNullableDeps',
+        import: 'source.dart',
+      );
+
+      final dependencyType = ImportableType(
+        name: 'SimpleFactory',
+        import: 'source.dart',
+        isNullable: true,
+      );
+      expect(
+        DependencyConfig(
+            type: type,
+            typeImpl: type,
+            injectableType: InjectableType.factory,
+            dependencies: [
+              InjectedDependency(
+                type: dependencyType,
+                paramName: 'simpleFactory',
+              )
+            ]),
+        dependencyResolver!.resolve(FactoryWithDeps),
+      );
+    });
+
     test('Simple Factory as abstract no dependencies', () {
       var factoryAsAbstract =
           resolvedInput!.library.findType('FactoryAsAbstract')!;
@@ -93,6 +121,37 @@ void main() async {
           injectableType: InjectableType.factory,
         ),
         equals(dependencyResolver!.resolve(factoryAsAbstract)),
+      );
+    });
+
+    test('Async factory with nullable dependencies', () {
+      final FactoryWithDeps =
+          resolvedInput!.library.findType('AsyncFactoryWithNullableDeps')!;
+      final type = ImportableType(
+        name: 'AsyncFactoryWithNullableDeps',
+        import: 'source.dart',
+      );
+
+      final dependencyType = ImportableType(
+        name: 'AsyncFactory',
+        import: 'source.dart',
+        isNullable: true,
+      );
+      expect(
+        DependencyConfig(
+            type: type,
+            typeImpl: type,
+            injectableType: InjectableType.factory,
+            dependencies: [
+              InjectedDependency(
+                type: dependencyType,
+                paramName: 'asyncFactory',
+                isFactoryParam: true,
+              )
+            ],
+            isAsync: true,
+            constructorName: 'create'),
+        dependencyResolver!.resolve(FactoryWithDeps),
       );
     });
   });

--- a/injectable_generator/test/resolver/samples/source.dart
+++ b/injectable_generator/test/resolver/samples/source.dart
@@ -4,9 +4,6 @@ import 'package:injectable/injectable.dart';
 class SimpleFactory {}
 
 @injectable
-class AsyncFactory {}
-
-@injectable
 class FactoryWithDeps {
   const FactoryWithDeps(SimpleFactory simpleFactory);
 }
@@ -17,21 +14,32 @@ class FactoryWithNullableDeps {
 }
 
 @injectable
+class FactoryWithFactoryParams {
+  const FactoryWithFactoryParams(@factoryParam SimpleFactory simpleFactory);
+}
+
+@injectable
+class FactoryWithNullableFactoryParams {
+  const FactoryWithNullableFactoryParams(
+      @factoryParam SimpleFactory? simpleFactory);
+}
+
+@injectable
 class AsyncFactoryWithNullableDeps {
-  const AsyncFactoryWithNullableDeps(AsyncFactory? asyncFactory);
+  const AsyncFactoryWithNullableDeps(SimpleFactory? simpleFactory);
   @factoryMethod
   static Future<AsyncFactoryWithNullableDeps> create(
-      @factoryParam AsyncFactory? asyncFactory) async {
-    return AsyncFactoryWithNullableDeps(asyncFactory);
+      @factoryParam SimpleFactory? simpleFactory) async {
+    return AsyncFactoryWithNullableDeps(simpleFactory);
   }
 }
 
 class AsyncFactoryWithNonNullableDeps {
-  const AsyncFactoryWithNonNullableDeps(AsyncFactory asyncFactory);
+  const AsyncFactoryWithNonNullableDeps(SimpleFactory simpleFactory);
   @factoryMethod
   static Future<AsyncFactoryWithNonNullableDeps> create(
-      @factoryParam AsyncFactory asyncFactory) async {
-    return AsyncFactoryWithNonNullableDeps(asyncFactory);
+      @factoryParam SimpleFactory simpleFactory) async {
+    return AsyncFactoryWithNonNullableDeps(simpleFactory);
   }
 }
 

--- a/injectable_generator/test/resolver/samples/source.dart
+++ b/injectable_generator/test/resolver/samples/source.dart
@@ -4,8 +4,35 @@ import 'package:injectable/injectable.dart';
 class SimpleFactory {}
 
 @injectable
+class AsyncFactory {}
+
+@injectable
 class FactoryWithDeps {
   const FactoryWithDeps(SimpleFactory simpleFactory);
+}
+
+@injectable
+class FactoryWithNullableDeps {
+  const FactoryWithNullableDeps(SimpleFactory? simpleFactory);
+}
+
+@injectable
+class AsyncFactoryWithNullableDeps {
+  const AsyncFactoryWithNullableDeps(AsyncFactory? asyncFactory);
+  @factoryMethod
+  static Future<AsyncFactoryWithNullableDeps> create(
+      @factoryParam AsyncFactory? asyncFactory) async {
+    return AsyncFactoryWithNullableDeps(asyncFactory);
+  }
+}
+
+class AsyncFactoryWithNonNullableDeps {
+  const AsyncFactoryWithNonNullableDeps(AsyncFactory asyncFactory);
+  @factoryMethod
+  static Future<AsyncFactoryWithNonNullableDeps> create(
+      @factoryParam AsyncFactory asyncFactory) async {
+    return AsyncFactoryWithNonNullableDeps(asyncFactory);
+  }
 }
 
 abstract class IFactory {}


### PR DESCRIPTION
Fix issue #267 

Bump minimal GetIt version to 7.2.0

Add some Resolver Tests

GetIt PR reference: https://github.com/fluttercommunity/get_it/pull/214/files