### PR TITLE
add the "Order" annotation to manually override generated order

### DIFF
--- a/injectable/lib/src/injectable_annotations.dart
+++ b/injectable/lib/src/injectable_annotations.dart
@@ -225,3 +225,17 @@ class DisposeMethod {
 /// const instance of [DisposeMethod]
 /// with default arguments
 const disposeMethod = DisposeMethod._();
+
+/// Classes annotated with @Order will overwrite
+/// the automatically generated position of the
+class Order {
+  /// determins the position in the order of generated GetIt functions
+  final int position;
+
+  /// default constructor
+  const Order(this.position);
+}
+
+/// const instance of [Order]
+/// with default arguments
+const order = Order(0);

--- a/injectable_generator/lib/code_builder/builder_utils.dart
+++ b/injectable_generator/lib/code_builder/builder_utils.dart
@@ -10,7 +10,17 @@ Set<DependencyConfig> sortDependencies(List<DependencyConfig> deps) {
   // sort dependencies by their register order
   final Set<DependencyConfig> sorted = {};
   _sortByDependents(deps.toSet(), sorted);
-  return sorted;
+  // sort dependencies by their orderPosition
+  final orderSorted = sorted.toList()..sort(_sortDependencyConfigByOrder);
+  return orderSorted.toSet();
+}
+
+int _sortDependencyConfigByOrder(
+  DependencyConfig current,
+  DependencyConfig next,
+) {
+  if (next.orderPosition == current.orderPosition) return 0;
+  return next.orderPosition > current.orderPosition ? 1 : -1;
 }
 
 void _sortByDependents(

--- a/injectable_generator/lib/code_builder/builder_utils.dart
+++ b/injectable_generator/lib/code_builder/builder_utils.dart
@@ -20,7 +20,7 @@ int _sortDependencyConfigByOrder(
   DependencyConfig next,
 ) {
   if (next.orderPosition == current.orderPosition) return 0;
-  return next.orderPosition > current.orderPosition ? 1 : -1;
+  return next.orderPosition > current.orderPosition ? -1 : 1;
 }
 
 void _sortByDependents(

--- a/injectable_generator/lib/models/dependency_config.dart
+++ b/injectable_generator/lib/models/dependency_config.dart
@@ -25,6 +25,7 @@ class DependencyConfig {
   final bool preResolve;
   final ModuleConfig? moduleConfig;
   final DisposeFunctionConfig? disposeFunction;
+  final int orderPosition;
 
   const DependencyConfig({
     required this.type,
@@ -40,6 +41,7 @@ class DependencyConfig {
     this.preResolve = false,
     this.moduleConfig,
     this.disposeFunction,
+    this.orderPosition = 0,
   });
 
   // used for testing
@@ -99,7 +101,8 @@ class DependencyConfig {
           ListEquality().equals(dependsOn, other.dependsOn) &&
           preResolve == other.preResolve &&
           disposeFunction == other.disposeFunction &&
-          moduleConfig == other.moduleConfig);
+          moduleConfig == other.moduleConfig &&
+          orderPosition == other.orderPosition);
 
   @override
   int get hashCode =>
@@ -115,7 +118,8 @@ class DependencyConfig {
       ListEquality().hash(dependsOn) ^
       preResolve.hashCode ^
       disposeFunction.hashCode ^
-      moduleConfig.hashCode;
+      moduleConfig.hashCode^
+      orderPosition.hashCode;
 
   factory DependencyConfig.fromJson(Map<dynamic, dynamic> json) {
     ModuleConfig? moduleConfig;
@@ -158,6 +162,7 @@ class DependencyConfig {
       preResolve: json['preResolve'] as bool,
       moduleConfig: moduleConfig,
       disposeFunction: disposeFunction,
+      orderPosition: json['orderPosition'] as int,
     );
   }
 
@@ -176,6 +181,7 @@ class DependencyConfig {
         if (instanceName != null) "instanceName": instanceName,
         if (signalsReady != null) "signalsReady": signalsReady,
         if (constructorName != null) "constructorName": constructorName,
+        "orderPosition": orderPosition,
       };
 
   bool get isFromModule => moduleConfig != null;

--- a/injectable_generator/lib/resolvers/dependency_resolver.dart
+++ b/injectable_generator/lib/resolvers/dependency_resolver.dart
@@ -23,6 +23,8 @@ const TypeChecker _factoryMethodChecker =
 const TypeChecker _disposeMethodChecker =
     TypeChecker.fromRuntime(DisposeMethod);
 
+const TypeChecker _orderChecker = TypeChecker.fromRuntime(Order);
+
 class DependencyResolver {
   final ImportableTypeResolver _typeResolver;
 
@@ -39,6 +41,7 @@ class DependencyResolver {
   List<InjectedDependency> _dependencies = [];
   ModuleConfig? _moduleConfig;
   DisposeFunctionConfig? _disposeFunctionConfig;
+  int _order = 0;
 
   DependencyResolver(this._typeResolver);
 
@@ -159,7 +162,8 @@ class DependencyResolver {
         const [];
 
     _preResolve = _preResolveChecker.hasAnnotationOfExact(annotatedElement);
-
+    _order = _orderChecker.firstAnnotationOfExact(annotatedElement)?.getField('position')?.toIntValue() ?? 0;
+  
     final name = _namedChecker
         .firstAnnotationOfExact(annotatedElement)
         ?.getField('name')
@@ -203,6 +207,8 @@ class DependencyResolver {
             disposeFuncFromAnnotation.type, disposeFuncFromAnnotation),
       );
     }
+
+
 
     late ExecutableElement executableInitializer;
     if (excModuleMember != null && !excModuleMember.isAbstract) {
@@ -295,6 +301,7 @@ class DependencyResolver {
       constructorName: _constructorName,
       isAsync: _isAsync,
       disposeFunction: _disposeFunctionConfig,
+      orderPosition: _order,
     );
   }
 }


### PR DESCRIPTION
implements https://github.com/Milad-Akarie/injectable/issues/272

by default the order position of every dependency is 0, and therefore the currently generated order won't change.

a simple way of overwriting the position of the generated get_it method is for example adding @Order(-1) to put it before everything else or @Order(1) for after.

or order all your classes manually by filling out any number higher or lower.
