### PR TITLE
Update README to reflect current state of the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,20 @@ dev_dependencies:
 
 1. Create a new dart file and define a global var for your GetIt instance.
 2. Define a top-level function (lets call it configureDependencies) then annotate it with @injectableInit.
-3. Call the **Generated** func getIt.init(), or your custom initializer name inside your configure func and pass in the getIt instance.
+3. Import the **Generated** dart file created later on in the code. This will follow the name of the file with the `@InjectableInit` annotated func, eg `file_name.config.dart`.
+4. Call the **Generated** extension func getIt.init(), or your custom initializer name inside your configure func.
+	
+Note: This example is for version 2+
 
 ```dart  
+import '<FILE_NAME>.config.dart';
+	
 final getIt = GetIt.instance;  
   
 @InjectableInit(  
   initializerName: 'init', // default  
   preferRelativeImports: true, // default  
-  asExtension: false, // default  
+  asExtension: true, // default  
 )  
 void configureDependencies() => getIt.init();  
 ```  
@@ -66,6 +71,8 @@ Note: you can tell injectable what directories to generate for using the generat
 The following example will only process files inside of the test folder.
 
 ```dart  
+import '<FILE_NAME>.config.dart';
+	
 @InjectableInit(generateForDir: ['test'])  
 void configureDependencies() => getIt.init();  
 ```  


### PR DESCRIPTION
I personally spent a couple hours trying to figure out why the example code was not working for me and it turned out to be a combination of things:

The `asExtension` parameter should be true (Which is now the default) and I was not importing the generated code. Both of these have been previous topics of discussion on SO and the repo, so it made sense address them to prevent further confusion.

* https://stackoverflow.com/questions/63370674/the-function-initgetit-isnt-defined-while-using-injectable-pub-package/63668392#63668392
* https://github.com/Milad-Akarie/injectable/issues/326

Note: The last diff seems to be adding and deleting the same line, which seems like an issue with the GitHub editor.