### PR TITLE
Optimize injectable_generator async analysis

### DIFF
--- a/injectable_generator/lib/code_builder/builder_utils.dart
+++ b/injectable_generator/lib/code_builder/builder_utils.dart
@@ -92,7 +92,6 @@ extension _InjectedDependencyX on InjectedDependency {
 
 @visibleForTesting
 Set<DependencyConfig> sortDependencies(Iterable<DependencyConfig> it) {
-  print('Sorting dependencies');
   // sort dependencies alphabetically
   final deps = it.toList()..sortBy((e) => e.type.name);
   // sort dependencies by their register order
@@ -100,7 +99,6 @@ Set<DependencyConfig> sortDependencies(Iterable<DependencyConfig> it) {
   _sortByDependents(deps.toSet(), sorted);
   // sort dependencies by their orderPosition
   final s = sorted.sortedBy<num>((e) => e.orderPosition).toSet();
-  print('Done sorting dependencies');
   return s;
 }
 

--- a/injectable_generator/lib/code_builder/builder_utils.dart
+++ b/injectable_generator/lib/code_builder/builder_utils.dart
@@ -1,18 +1,109 @@
+import 'dart:collection';
+
 import 'package:code_builder/code_builder.dart';
 import 'package:collection/collection.dart';
 import 'package:injectable_generator/models/dependency_config.dart';
 import 'package:injectable_generator/models/importable_type.dart';
 import 'package:injectable_generator/models/injected_dependency.dart';
 import 'package:injectable_generator/resolvers/importable_type_resolver.dart';
+import 'package:meta/meta.dart';
 
-Set<DependencyConfig> sortDependencies(List<DependencyConfig> deps) {
+class DependencySet with IterableMixin<DependencyConfig> {
+  final Set<DependencyConfig> _dependencies;
+  late final Map<_DependencyId, List<DependencyConfig>> _lookupTable =
+      _dependencies.groupListsBy((d) => d.id);
+
+  DependencySet({
+    required Iterable<DependencyConfig> dependencies,
+  }) : _dependencies = sortDependencies(dependencies);
+
+  bool hasAsyncDependency(DependencyConfig dep) {
+    _ensureAsyncDepsMapInitialized();
+    return _hasAsyncDeps![dep.id] ?? false;
+  }
+
+  bool isAsyncOrHasAsyncDependency(InjectedDependency iDep) {
+    _ensureAsyncDepsMapInitialized();
+    return _isAsyncOrHasAsyncDeps![iDep.id] ?? false;
+  }
+
+  Map<_DependencyId, bool>? _hasAsyncDeps;
+  Map<_DependencyId, bool>? _isAsyncOrHasAsyncDeps;
+
+  void _ensureAsyncDepsMapInitialized() {
+    if (_hasAsyncDeps != null) {
+      return;
+    }
+
+    final hasAsyncDepsMap = <_DependencyId, bool>{};
+    final isAsyncOrHasAsyncDepsMap = <_DependencyId, bool>{};
+
+    for (final dep in _dependencies) {
+      final hasAsyncDeps = dep.dependencies.any((childDependency) {
+        final cid = childDependency.id;
+        return isAsyncOrHasAsyncDepsMap[cid] ?? false;
+      });
+
+      final did = dep.id;
+      hasAsyncDepsMap[did] = hasAsyncDeps;
+      isAsyncOrHasAsyncDepsMap[did] =
+          (dep.isAsync && !dep.preResolve) || hasAsyncDeps;
+    }
+
+    _hasAsyncDeps = hasAsyncDepsMap;
+    _isAsyncOrHasAsyncDeps = isAsyncOrHasAsyncDepsMap;
+  }
+
+  @override
+  Iterator<DependencyConfig> get iterator => _dependencies.iterator;
+}
+
+class _DependencyId {
+  final ImportableType type;
+  final String? instanceName;
+
+  const _DependencyId({
+    required this.type,
+    required this.instanceName,
+  });
+
+  @override
+  String toString() {
+    return 'DependencyId{type: $type, instanceName: $instanceName}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is _DependencyId &&
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          instanceName == other.instanceName);
+
+  @override
+  int get hashCode => Object.hash(type, instanceName);
+}
+
+extension _DependencyConfigX on DependencyConfig {
+  _DependencyId get id => _DependencyId(type: type, instanceName: instanceName);
+}
+
+extension _InjectedDependencyX on InjectedDependency {
+  _DependencyId get id => _DependencyId(type: type, instanceName: instanceName);
+}
+
+@visibleForTesting
+Set<DependencyConfig> sortDependencies(Iterable<DependencyConfig> it) {
+  print('Sorting dependencies');
   // sort dependencies alphabetically
-  deps.sortBy((e) => e.type.name);
+  final deps = it.toList()..sortBy((e) => e.type.name);
   // sort dependencies by their register order
   final Set<DependencyConfig> sorted = {};
   _sortByDependents(deps.toSet(), sorted);
   // sort dependencies by their orderPosition
-  return sorted.sortedBy<num>((e) => e.orderPosition).toSet();
+  final s = sorted.sortedBy<num>((e) => e.orderPosition).toSet();
+  print('Done sorting dependencies');
+  return s;
 }
 
 void _sortByDependents(
@@ -40,44 +131,6 @@ void _sortByDependents(
   if (unSorted.isNotEmpty) {
     _sortByDependents(unSorted.difference(sorted), sorted);
   }
-}
-
-bool isAsyncOrHasAsyncDependency(
-    InjectedDependency iDep, Set<DependencyConfig> allDeps) {
-  final dep = lookupDependency(iDep, allDeps);
-  if (dep == null) {
-    return false;
-  }
-
-  if (dep.isAsync && !dep.preResolve) {
-    return true;
-  }
-
-  return hasAsyncDependency(dep, allDeps);
-}
-
-bool hasAsyncDependency(DependencyConfig dep, Set<DependencyConfig> allDeps) {
-  for (final iDep in dep.dependencies) {
-    var config = lookupDependency(iDep, allDeps);
-
-    // If the dependency corresponding to the InjectedDependency couldn't be
-    // found, this probably indicates there is a missing dependency.
-    if (config == null) {
-      continue;
-    }
-
-    // Ultimately, this is what we're looking for:
-    if (config.isAsync && !config.preResolve) {
-      return true;
-    }
-
-    // If the dependency itself isn't async, check to see if any of *its*
-    // dependencies are async.
-    if (hasAsyncDependency(config, allDeps)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 DependencyConfig? lookupDependency(
@@ -111,7 +164,7 @@ Set<DependencyConfig> lookupPossibleDeps(
       .toSet();
 }
 
-bool hasPreResolvedDependencies(Set<DependencyConfig> deps) {
+bool hasPreResolvedDependencies(Iterable<DependencyConfig> deps) {
   return deps.any((d) => d.isAsync && d.preResolve);
 }
 

--- a/injectable_generator/lib/code_builder/builder_utils.dart
+++ b/injectable_generator/lib/code_builder/builder_utils.dart
@@ -10,8 +10,6 @@ import 'package:meta/meta.dart';
 
 class DependencySet with IterableMixin<DependencyConfig> {
   final Set<DependencyConfig> _dependencies;
-  late final Map<_DependencyId, List<DependencyConfig>> _lookupTable =
-      _dependencies.groupListsBy((d) => d.id);
 
   DependencySet({
     required Iterable<DependencyConfig> dependencies,

--- a/injectable_generator/lib/code_builder/library_builder.dart
+++ b/injectable_generator/lib/code_builder/library_builder.dart
@@ -16,7 +16,7 @@ const _ghRefer = Reference('GetItHelper', _injectableImport);
 const _ghLocalRefer = Reference('gh');
 
 mixin SharedGeneratorCode {
-  Set<DependencyConfig> get dependencies;
+  DependencySet get dependencies;
 
   Uri? get targetFile;
 
@@ -65,11 +65,9 @@ mixin SharedGeneratorCode {
     }
     getAsyncReferName ??= asExtension ? 'getAsync' : 'gh.getAsync';
     getReferName ??= 'gh';
-    final isAsync = isAsyncOrHasAsyncDependency(iDep, dependencies);
-    final expression =
-        refer(isAsync ? getAsyncReferName : getReferName).call([], {
-      if (iDep.instanceName != null)
-        'instanceName': literalString(iDep.instanceName!),
+    final isAsync = dependencies.isAsyncOrHasAsyncDependency(iDep);
+    final expression = refer(isAsync ? getAsyncReferName : getReferName).call([], {
+      if (iDep.instanceName != null) 'instanceName': literalString(iDep.instanceName!),
     }, [
       typeRefer(iDep.type, targetFile, false),
     ]);
@@ -79,7 +77,7 @@ mixin SharedGeneratorCode {
 
 class LibraryGenerator with SharedGeneratorCode {
   @override
-  late Set<DependencyConfig> dependencies;
+  late DependencySet dependencies;
   @override
   final Uri? targetFile;
   @override
@@ -90,14 +88,14 @@ class LibraryGenerator with SharedGeneratorCode {
       microPackagesModulesAfter;
 
   LibraryGenerator({
-    required this.dependencies,
+    required Set<DependencyConfig> dependencies,
     required this.initializerName,
     this.targetFile,
     this.asExtension = false,
     this.microPackageName,
     this.microPackagesModulesBefore = const {},
     this.microPackagesModulesAfter = const {},
-  });
+  }) : dependencies = DependencySet(dependencies: dependencies);
 
   Library generate() {
     // all environment keys used
@@ -254,13 +252,13 @@ class LibraryGenerator with SharedGeneratorCode {
 
 class InitMethodGenerator with SharedGeneratorCode {
   @override
-  late Set<DependencyConfig> dependencies;
+  late DependencySet dependencies;
   @override
   final Uri? targetFile;
   @override
   final bool asExtension;
 
-  final Set<DependencyConfig> allDependencies;
+  final DependencySet allDependencies;
   final String initializerName;
   final String? scopeName;
   final bool isMicroPackage;
@@ -277,10 +275,8 @@ class InitMethodGenerator with SharedGeneratorCode {
     this.isMicroPackage = false,
     this.microPackagesModulesBefore = const {},
     this.microPackagesModulesAfter = const {},
-  }) {
-    assert(microPackagesModulesBefore.isEmpty || scopeName == null);
-    dependencies = sortDependencies(scopeDependencies);
-  }
+  })  : assert(microPackagesModulesBefore.isEmpty || scopeName == null),
+        dependencies = DependencySet(dependencies: scopeDependencies);
 
   Method generate() {
     // if true use an awaited initializer
@@ -446,7 +442,7 @@ class InitMethodGenerator with SharedGeneratorCode {
   Code buildLazyRegisterFun(DependencyConfig dep) {
     String? funcReferName;
     Map<String, Reference> factoryParams = {};
-    final hasAsyncDep = hasAsyncDependency(dep, dependencies);
+    final hasAsyncDep = dependencies.hasAsyncDependency(dep);
     final isOrHasAsyncDep = dep.isAsync || hasAsyncDep;
 
     if (dep.injectableType == InjectableType.factory) {
@@ -549,7 +545,7 @@ class InitMethodGenerator with SharedGeneratorCode {
   Code buildSingletonRegisterFun(DependencyConfig dep) {
     String funcReferName;
     var asFactory = true;
-    final hasAsyncDep = hasAsyncDependency(dep, dependencies);
+    final hasAsyncDep = dependencies.hasAsyncDependency(dep);
     if (dep.isAsync || hasAsyncDep) {
       funcReferName = 'singletonAsync';
     } else if (dep.dependsOn.isNotEmpty) {

--- a/injectable_generator/lib/code_builder/library_builder.dart
+++ b/injectable_generator/lib/code_builder/library_builder.dart
@@ -66,8 +66,10 @@ mixin SharedGeneratorCode {
     getAsyncReferName ??= asExtension ? 'getAsync' : 'gh.getAsync';
     getReferName ??= 'gh';
     final isAsync = dependencies.isAsyncOrHasAsyncDependency(iDep);
-    final expression = refer(isAsync ? getAsyncReferName : getReferName).call([], {
-      if (iDep.instanceName != null) 'instanceName': literalString(iDep.instanceName!),
+    final expression =
+        refer(isAsync ? getAsyncReferName : getReferName).call([], {
+      if (iDep.instanceName != null)
+        'instanceName': literalString(iDep.instanceName!),
     }, [
       typeRefer(iDep.type, targetFile, false),
     ]);

--- a/injectable_generator/pubspec.lock
+++ b/injectable_generator/pubspec.lock
@@ -306,7 +306,7 @@ packages:
     source: hosted
     version: "0.12.16"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"

--- a/injectable_generator/pubspec.yaml
+++ b/injectable_generator/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
 #    path: ../injectable
   collection: ^1.15.0
   recase: ^4.1.0
+  meta: ^1.9.1
 dev_dependencies:
   build_runner: ^2.3.3
   build_test: ^2.1.3

--- a/injectable_generator/test/code_builder/builder_utils_test.dart
+++ b/injectable_generator/test/code_builder/builder_utils_test.dart
@@ -104,7 +104,8 @@ void main() {
         injectableType: InjectableType.factory,
       );
       final allDeps = {dep};
-      expect(hasAsyncDependency(dep, allDeps), isFalse);
+      final depSet = DependencySet(dependencies: allDeps);
+      expect(depSet.hasAsyncDependency(dep), isFalse);
     });
 
     test('should return `false` when all deps are not async', () {
@@ -127,7 +128,8 @@ void main() {
           injectableType: InjectableType.factory,
         ),
       };
-      expect(hasAsyncDependency(dep, allDeps), isFalse);
+      final depSet = DependencySet(dependencies: allDeps);
+      expect(depSet.hasAsyncDependency(dep), isFalse);
     });
 
     test('should return `false` for a missing dependency', () {
@@ -143,7 +145,8 @@ void main() {
         ],
       );
       final allDeps = <DependencyConfig>{dep};
-      expect(hasAsyncDependency(dep, allDeps), isFalse);
+      final depSet = DependencySet(dependencies: allDeps);
+      expect(depSet.hasAsyncDependency(dep), isFalse);
     });
 
     test('should return `true` when at least one dep is async', () {
@@ -178,7 +181,8 @@ void main() {
           instanceName: 'buzzImpl',
         ),
       };
-      expect(hasAsyncDependency(dep, allDeps), isTrue);
+      final depSet = DependencySet(dependencies: allDeps);
+      expect(depSet.hasAsyncDependency(dep), isTrue);
     });
 
     test('should return `true` when a named instance dep is async', () {
@@ -213,7 +217,8 @@ void main() {
           isAsync: true,
         ),
       };
-      expect(hasAsyncDependency(dep, allDeps), isTrue);
+      final depSet = DependencySet(dependencies: allDeps);
+      expect(depSet.hasAsyncDependency(dep), isTrue);
     });
 
     test('should return `true` when a transitive dep is async', () {
@@ -249,7 +254,8 @@ void main() {
           isAsync: true,
         ),
       };
-      expect(hasAsyncDependency(dep, allDeps), isTrue);
+      final depSet = DependencySet(dependencies: allDeps);
+      expect(depSet.hasAsyncDependency(dep), isTrue);
     });
   });
 
@@ -260,7 +266,8 @@ void main() {
         paramName: 'fizz',
       );
       final allDeps = <DependencyConfig>{};
-      expect(isAsyncOrHasAsyncDependency(iDep, allDeps), isFalse);
+      final depSet = DependencySet(dependencies: allDeps);
+      expect(depSet.isAsyncOrHasAsyncDependency(iDep), isFalse);
     });
 
     test('should return `false` when not async and no deps', () {
@@ -275,7 +282,8 @@ void main() {
         isAsync: false,
       );
       final allDeps = {dep};
-      expect(isAsyncOrHasAsyncDependency(iDep, allDeps), isFalse);
+      final depSet = DependencySet(dependencies: allDeps);
+      expect(depSet.isAsyncOrHasAsyncDependency(iDep), isFalse);
     });
     test('should return `false` when async but preResolve is true', () {
       final iDep = InjectedDependency(
@@ -290,7 +298,8 @@ void main() {
         preResolve: true,
       );
       final allDeps = {dep};
-      expect(isAsyncOrHasAsyncDependency(iDep, allDeps), isFalse);
+      final depSet = DependencySet(dependencies: allDeps);
+      expect(depSet.isAsyncOrHasAsyncDependency(iDep), isFalse);
     });
 
     test('should return `true` when async', () {
@@ -305,7 +314,8 @@ void main() {
         isAsync: true,
       );
       final allDeps = {dep};
-      expect(isAsyncOrHasAsyncDependency(iDep, allDeps), isTrue);
+      final depSet = DependencySet(dependencies: allDeps);
+      expect(depSet.isAsyncOrHasAsyncDependency(iDep), isTrue);
     });
 
     test('should return `false` when not async and no async deps', () {
@@ -332,7 +342,8 @@ void main() {
           injectableType: InjectableType.factory,
         )
       };
-      expect(isAsyncOrHasAsyncDependency(iDep, allDeps), isFalse);
+      final depSet = DependencySet(dependencies: allDeps);
+      expect(depSet.isAsyncOrHasAsyncDependency(iDep), isFalse);
     });
 
     test('should return `true` when has an async deps', () {
@@ -360,7 +371,8 @@ void main() {
           isAsync: true,
         )
       };
-      expect(isAsyncOrHasAsyncDependency(iDep, allDeps), isTrue);
+      final depSet = DependencySet(dependencies: allDeps);
+      expect(depSet.isAsyncOrHasAsyncDependency(iDep), isTrue);
     });
   });
 

--- a/injectable_generator/test/code_builder/eager_singleton_test.dart
+++ b/injectable_generator/test/code_builder/eager_singleton_test.dart
@@ -1,4 +1,5 @@
 import 'package:code_builder/code_builder.dart';
+import 'package:injectable_generator/code_builder/builder_utils.dart';
 import 'package:injectable_generator/code_builder/library_builder.dart';
 import 'package:injectable_generator/injectable_types.dart';
 import 'package:injectable_generator/models/dependency_config.dart';
@@ -208,7 +209,7 @@ void main() {
 String generate(DependencyConfig input, {List<DependencyConfig>? allDeps}) {
   final generator = InitMethodGenerator(
     scopeDependencies: allDeps ?? [],
-    allDependencies: allDeps?.toSet() ?? {},
+    allDependencies: DependencySet(dependencies: allDeps?.toSet() ?? {}),
     initializerName: 'init',
   );
   final statement = generator.buildSingletonRegisterFun(input);

--- a/injectable_generator/test/code_builder/factory_param_test.dart
+++ b/injectable_generator/test/code_builder/factory_param_test.dart
@@ -1,4 +1,5 @@
 import 'package:code_builder/code_builder.dart';
+import 'package:injectable_generator/code_builder/builder_utils.dart';
 import 'package:injectable_generator/code_builder/library_builder.dart';
 import 'package:injectable_generator/injectable_types.dart';
 import 'package:injectable_generator/models/dependency_config.dart';
@@ -136,7 +137,7 @@ void main() {
 String generate(DependencyConfig input, {List<DependencyConfig>? allDeps}) {
   final generator = InitMethodGenerator(
     scopeDependencies: allDeps ?? [],
-    allDependencies: allDeps?.toSet() ?? {},
+    allDependencies: DependencySet(dependencies: allDeps?.toSet() ?? {}),
     initializerName: 'init',
   );
   final statement = generator.buildLazyRegisterFun(input);

--- a/injectable_generator/test/code_builder/lazy_factory_test.dart
+++ b/injectable_generator/test/code_builder/lazy_factory_test.dart
@@ -1,4 +1,5 @@
 import 'package:code_builder/code_builder.dart';
+import 'package:injectable_generator/code_builder/builder_utils.dart';
 import 'package:injectable_generator/code_builder/library_builder.dart';
 import 'package:injectable_generator/injectable_types.dart';
 import 'package:injectable_generator/models/dependency_config.dart';
@@ -296,7 +297,7 @@ void main() {
 String generate(DependencyConfig input, {List<DependencyConfig>? allDeps}) {
   final generator = InitMethodGenerator(
     scopeDependencies: allDeps ?? [],
-    allDependencies: allDeps?.toSet() ?? {},
+    allDependencies: DependencySet(dependencies: allDeps?.toSet() ?? {}),
     initializerName: 'init',
   );
   final statement = generator.buildLazyRegisterFun(input);


### PR DESCRIPTION
Hi! I'm using `injectable_generator` in a fairly big project.
Codegen took a long time (several minutes) so I decided to investigate it.

In our project codegen time for injectable_generator almost doubled due to a small change, which implied poor scaling.
The culprit was the async analysis, I noticed it does not scale very well with large dependency graphs due to the recursive lookups it does for each registration.
Here's my attempt to improve it! :D 

I use a `DependencySet` that walks the dependency tree once (in order) to build a lookup table for async checks.
All tests are green after replacing the sets of dependency with the new `DependencySet`.

There's some room to optimize the sorting of dependencies as well, but I didn't touch that for now.

Let me know if you need anything from me to get this merged :)