### PR TITLE
fix: Typo in docs

### DIFF
--- a/injectable/lib/src/injectable_annotations.dart
+++ b/injectable/lib/src/injectable_annotations.dart
@@ -14,7 +14,7 @@ class InjectableInit {
 
   /// if true the init function
   /// will be generated inside
-  /// of a [GetIi] extension
+  /// of a [GetIt] extension
   /// defaults to true
   final bool asExtension;
 


### PR DESCRIPTION
Fixes small typo isnide `injectable_annotations.dart`