### PR TITLE
feat: Add root directory support

### DIFF
--- a/injectable/CHANGELOG.md
+++ b/injectable/CHANGELOG.md
@@ -1,4 +1,6 @@
 # ChangeLog
+## [2.3.0]
+- Added [rootDir] support for specifying the root directory for the generation process.
 ## [2.2.0]
 - Optimize injectable_generator async analysis by [https://github.com/Jjagg]
 - Update dart constrains to ">=3.0.0 <4.0.0"

--- a/injectable/lib/src/injectable_annotations.dart
+++ b/injectable/lib/src/injectable_annotations.dart
@@ -21,7 +21,7 @@ class InjectableInit {
   /// Example: ../../path/path2
   /// Absolute Path:
   /// Example: /Users/username/Downloads
-  final String rootDir;
+  final String? rootDir;
 
   /// if true the init function
   /// will be generated inside
@@ -76,7 +76,7 @@ class InjectableInit {
   /// default constructor
   const InjectableInit({
     this.generateForDir = const ['lib'],
-    this.rootDir = '.',
+    this.rootDir,
     this.preferRelativeImports = false,
     this.initializerName = 'init',
     this.ignoreUnregisteredTypes = const [],
@@ -105,7 +105,7 @@ class InjectableInit {
         asExtension = false,
         includeMicroPackages = false,
         initializerName = 'init',
-        rootDir = '.';
+        rootDir = null;
 }
 
 /// const instance of [InjectableInit]

--- a/injectable/lib/src/injectable_annotations.dart
+++ b/injectable/lib/src/injectable_annotations.dart
@@ -12,6 +12,17 @@ class InjectableInit {
   /// defaults to $init
   final String initializerName;
 
+
+  /// If [rootDir] is provided, generation processes will continue
+  /// through this dir.
+  /// You can define the [rootDir] in the following two ways:
+  ///
+  /// Relative Path:
+  /// Example: ../../path/path2
+  /// Absolute Path:
+  /// Example: /Users/username/Downloads
+  final String rootDir;
+
   /// if true the init function
   /// will be generated inside
   /// of a [GetIi] extension
@@ -65,6 +76,7 @@ class InjectableInit {
   /// default constructor
   const InjectableInit({
     this.generateForDir = const ['lib'],
+    this.rootDir = '.',
     this.preferRelativeImports = false,
     this.initializerName = 'init',
     this.ignoreUnregisteredTypes = const [],
@@ -92,7 +104,8 @@ class InjectableInit {
   })  : _isMicroPackage = true,
         asExtension = false,
         includeMicroPackages = false,
-        initializerName = 'init';
+        initializerName = 'init',
+        rootDir = '.';
 }
 
 /// const instance of [InjectableInit]

--- a/injectable/pubspec.yaml
+++ b/injectable/pubspec.yaml
@@ -1,6 +1,6 @@
 name: injectable
 description: Injectable is a convenient code generator for get_it. Inspired by Angular DI, Guice DI and inject.dart.
-version: 2.2.0
+version: 2.3.0
 homepage: https://github.com/Milad-Akarie/injectable
 
 environment:

--- a/injectable_generator/CHANGELOG.md
+++ b/injectable_generator/CHANGELOG.md
@@ -1,4 +1,6 @@
 # ChangeLog
+## [2.4.0]
+- Added [rootDir] support for specifying the root directory for the generation process.
 ## [2.3.0]
 - Revert: bumping up collection version to use 1.17.1
 - Refactor: the main scope init method will now always be generated even if it has no dependencies

--- a/injectable_generator/lib/generators/injectable_config_generator.dart
+++ b/injectable_generator/lib/generators/injectable_config_generator.dart
@@ -33,14 +33,14 @@ class InjectableConfigGenerator extends GeneratorForAnnotation<InjectableInit> {
     final isMicroPackage = annotation.read('_isMicroPackage').boolValue;
     final throwOnMissingDependencies =
         annotation.read('throwOnMissingDependencies').boolValue;
-    var targetFile = element.source?.uri;
-    var preferRelativeImports =
+    final targetFile = element.source?.uri;
+    final preferRelativeImports =
         annotation.read("preferRelativeImports").boolValue;
 
-    var includeMicroPackages =
+    final includeMicroPackages =
         annotation.read("includeMicroPackages").boolValue;
 
-    var rootDir = annotation.read("rootDir").stringValue;
+    final rootDir = annotation.peek('rootDir')?.stringValue;
 
     final dirPattern = generateForDir.length > 1
         ? '{${generateForDir.join(',')}}'

--- a/injectable_generator/lib/generators/injectable_config_generator.dart
+++ b/injectable_generator/lib/generators/injectable_config_generator.dart
@@ -40,6 +40,8 @@ class InjectableConfigGenerator extends GeneratorForAnnotation<InjectableInit> {
     var includeMicroPackages =
         annotation.read("includeMicroPackages").boolValue;
 
+    var rootDir = annotation.read("rootDir").stringValue;
+
     final dirPattern = generateForDir.length > 1
         ? '{${generateForDir.join(',')}}'
         : '${generateForDir.first}';
@@ -91,8 +93,10 @@ class InjectableConfigGenerator extends GeneratorForAnnotation<InjectableInit> {
     final microPackagesModules =
         microPackageModulesBefore.union(microPackageModulesAfter);
     if (!isMicroPackage && includeMicroPackages) {
-      await for (final match
-          in Glob('**.module.dart', recursive: true).list()) {
+      final glob = Glob('**.module.dart', recursive: true);
+      final filesStream = glob.list(root: rootDir);
+
+      await for (final match in filesStream) {
         final commentAnnotation = File(match.path).readAsLinesSync().first;
         if (commentAnnotation.contains('@GeneratedMicroModule')) {
           final segments = commentAnnotation.split(';');

--- a/injectable_generator/pubspec.yaml
+++ b/injectable_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: injectable_generator
 description: Injectable is a convenient code generator for get_it. Inspired by Angular DI, Guice DI and inject.dart.
-version: 2.3.0
+version: 2.4.0
 homepage: https://github.com/Milad-Akarie/injectable
 
 environment:


### PR DESCRIPTION
Hello again @Milad-Akarie  👋. 

This time, I have added a feature to specify the root directory for a generation. I aim to address the issue of not being included in the micro package generation process

For example, if we have a project structured as follows,

```
.
└── Example Application/
    ├── app/
    │   └── lib/
    │       ├── app/
    │       │   └── dependency_injection/
    │       │       └── dependency_injection.dart
    │       └── main.dart
    ├── modules/
    │   ├── core/
    │   │   ├── lib
    │   │   └── pubspec.yaml
    │   ├── data/
    │   │   ├── lib
    │   │   └── pubspec.yaml
    │   ├── domain/
    │   │   ├── lib
    │   │   └── pubspec.yaml
    │   └── features/
    │       ├── feature#1/
    │       │   ├── lib
    │       │   └── pubspec.yaml
    │       └── feature#2/
    │           ├── lib
    │           └── pubspec.yaml
    └── pubspec.yaml
```


Problem: If we run build_runner within the app directory, the generated 'dependency_injection.config.dart' file will not include micro packages from the 'modules'.

Solution: By using the [rootDir] parameter, the user can designate the parent directory as the main directory, enabling the generator to spread across a broader area.