### PR TITLE
Fix for #392 - Allows for working with only microPackageModules

### DIFF
--- a/injectable_generator/lib/code_builder/library_builder.dart
+++ b/injectable_generator/lib/code_builder/library_builder.dart
@@ -431,10 +431,7 @@ class InitMethodGenerator with SharedGeneratorCode {
                   .statement
             else ...[
               if (!isMicroPackage)
-                if (dependencies.isNotEmpty)
-                  declareFinal('gh').assign(ghBuilder).statement
-                else
-                  ghBuilder.statement,
+                declareFinal('gh').assign(ghBuilder).statement,
               ...ghStatements,
               if (!isMicroPackage) getInstanceRefer.returned.statement,
             ],


### PR DESCRIPTION
Given it some thought, despite that this will generate an unused variable incase that 0 dependencies are added in the root lib folder, one shouldn't generate the container if one doesn't add any dependencies.

This does not generate the error in #392 anymore 