### PR TITLE
fix: PreResolved singletons/factories fail checking environment filters

### DIFF
--- a/injectable/lib/src/get_it_helper.dart
+++ b/injectable/lib/src/get_it_helper.dart
@@ -92,6 +92,7 @@ class GetItHelper {
           (instance) => factory(
             () => instance,
             instanceName: instanceName,
+            registerFor: registerFor,
           ),
         );
       } else {
@@ -166,6 +167,7 @@ class GetItHelper {
           (instance) => lazySingleton(
             () => instance,
             instanceName: instanceName,
+            registerFor: registerFor,
             dispose: dispose,
           ),
         );
@@ -217,6 +219,7 @@ class GetItHelper {
             instance,
             instanceName: instanceName,
             signalsReady: signalsReady,
+            registerFor: registerFor,
             dispose: dispose,
           ),
         );


### PR DESCRIPTION
When it is resolved, the instance is passed to the non-async method, which checks again if it can be registered, but it may fail because the original collected environments (registerFor) are not passed.