### PR TITLE
feat: ignore all lints in generated files

### DIFF
--- a/injectable_generator/lib/code_builder/library_builder.dart
+++ b/injectable_generator/lib/code_builder/library_builder.dart
@@ -162,8 +162,7 @@ class LibraryGenerator with SharedGeneratorCode {
     return Library(
       (b) => b
         ..comments.addAll([
-          'ignore_for_file: unnecessary_lambdas',
-          'ignore_for_file: lines_longer_than_80_chars',
+          'ignore_for_file: type=lint',
           'coverage:ignore-file',
         ])
         ..body.addAll(

--- a/injectable_generator/test/code_builder/library_test.dart
+++ b/injectable_generator/test/code_builder/library_test.dart
@@ -8,8 +8,7 @@ void main() {
   group('Library test group', () {
     test("Simple init function", () {
       expect(generate([DependencyConfig.factory('Demo')]), '''
-// ignore_for_file: unnecessary_lambdas
-// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: type=lint
 // coverage:ignore-file
 
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -31,8 +30,7 @@ GetIt init(
 
     test("Simple asExtension init", () {
       expect(generate([DependencyConfig.factory('Demo')], asExt: true), '''
-// ignore_for_file: unnecessary_lambdas
-// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: type=lint
 // coverage:ignore-file
 
 extension GetItInjectableX on GetIt {


### PR DESCRIPTION
@Milad-Akarie  Ignore all lints for generated files. If using stricter lint rules some generated files lead to analyzer errors.