### PR TITLE
fix: Postpone singleton initialisation to respect environment filters

### DIFF
--- a/injectable/lib/src/get_it_helper.dart
+++ b/injectable/lib/src/get_it_helper.dart
@@ -185,7 +185,7 @@ class GetItHelper {
   /// a conditional wrapper method for getIt.registerSingleton
   /// it only registers if [_canRegister] returns true
   void singleton<T extends Object>(
-    T instance, {
+    FactoryFunc<T> factoryFunc, {
     String? instanceName,
     bool? signalsReady,
     Set<String>? registerFor,
@@ -193,7 +193,7 @@ class GetItHelper {
   }) {
     if (_canRegister(registerFor)) {
       getIt.registerSingleton<T>(
-        instance,
+        factoryFunc(),
         instanceName: instanceName,
         signalsReady: signalsReady,
         dispose: dispose,
@@ -216,7 +216,7 @@ class GetItHelper {
       if (preResolve) {
         return factoryFunc().then(
           (instance) => singleton(
-            instance,
+            () => instance,
             instanceName: instanceName,
             signalsReady: signalsReady,
             registerFor: registerFor,

--- a/injectable_generator/lib/code_builder/library_builder.dart
+++ b/injectable_generator/lib/code_builder/library_builder.dart
@@ -549,14 +549,12 @@ class InitMethodGenerator with SharedGeneratorCode {
 
   Code buildSingletonRegisterFun(DependencyConfig dep) {
     String funcReferName;
-    var asFactory = true;
     final hasAsyncDep = dependencies.hasAsyncDependency(dep);
     if (dep.isAsync || hasAsyncDep) {
       funcReferName = 'singletonAsync';
     } else if (dep.dependsOn.isNotEmpty) {
       funcReferName = 'singletonWithDependencies';
     } else {
-      asFactory = false;
       funcReferName = 'singleton';
     }
 
@@ -564,12 +562,10 @@ class InitMethodGenerator with SharedGeneratorCode {
         dep.isFromModule ? _buildInstanceForModule(dep) : _buildInstance(dep);
     final instanceBuilderCode = _buildInstanceBuilderCode(instanceBuilder, dep);
     final registerExpression = _ghLocalRefer.property(funcReferName).call([
-      asFactory
-          ? Method((b) => b
-            ..lambda = instanceBuilderCode is! Block
-            ..modifier = hasAsyncDep ? MethodModifier.async : null
-            ..body = instanceBuilderCode).closure
-          : CodeExpression(instanceBuilderCode)
+      Method((b) => b
+        ..lambda = instanceBuilderCode is! Block
+        ..modifier = hasAsyncDep ? MethodModifier.async : null
+        ..body = instanceBuilderCode).closure
     ], {
       if (dep.instanceName != null)
         'instanceName': literalString(dep.instanceName!),


### PR DESCRIPTION
Passing the instance on singleton registration causes object instantiation before evaluating if it can be registered with provided environment filter. With this change, the initialisation is delegated to the factory function which won't be executed before filter evaluation.