### PR TITLE
Added an "retrieval callback" parameter/hook

### DIFF
--- a/injectable/lib/src/get_it_helper.dart
+++ b/injectable/lib/src/get_it_helper.dart
@@ -11,9 +11,12 @@ class GetItHelper {
   /// filter for whether to register for the given set of environments
   late final EnvironmentFilter _environmentFilter;
 
+  /// callback for instance
+  late final Object Function(Object) _instanceCallback;
+
   /// creates a new instance of GetItHelper
   GetItHelper(this.getIt,
-      [String? environment, EnvironmentFilter? environmentFilter])
+      [String? environment, EnvironmentFilter? environmentFilter, Object Function(Object)? instanceCallback])
       : assert(environmentFilter == null || environment == null) {
     // register current EnvironmentsFilter as lazy singleton
     if (!getIt.isRegistered<EnvironmentFilter>(
@@ -27,6 +30,9 @@ class GetItHelper {
       _environmentFilter =
           getIt<EnvironmentFilter>(instanceName: kEnvironmentsFilterName);
     }
+
+    // ensure instance callback is initialized to at least a benign passthrough
+    _instanceCallback = instanceCallback ?? (o) => o;
 
     // register current Environments as lazy singleton
     if (!getIt.isRegistered<Set<String>>(instanceName: kEnvironmentsName)) {
@@ -42,11 +48,12 @@ class GetItHelper {
     dynamic param1,
     dynamic param2,
   }) =>
+      _instanceCallback(
       getIt.get<T>(
         instanceName: instanceName,
         param1: param1,
         param2: param2,
-      );
+      )) as T;
 
   Future<T> getAsync<T extends Object>({
     String? instanceName,

--- a/injectable/lib/src/get_it_helper.dart
+++ b/injectable/lib/src/get_it_helper.dart
@@ -12,11 +12,11 @@ class GetItHelper {
   late final EnvironmentFilter _environmentFilter;
 
   /// callback for instance
-  late final Object Function(Object) _instanceCallback;
+  late final Object Function(Object) _retrievalCallback;
 
   /// creates a new instance of GetItHelper
   GetItHelper(this.getIt,
-      [String? environment, EnvironmentFilter? environmentFilter, Object Function(Object)? instanceCallback])
+      [String? environment, EnvironmentFilter? environmentFilter, Object Function(Object)? retrievalCallback])
       : assert(environmentFilter == null || environment == null) {
     // register current EnvironmentsFilter as lazy singleton
     if (!getIt.isRegistered<EnvironmentFilter>(
@@ -32,7 +32,7 @@ class GetItHelper {
     }
 
     // ensure instance callback is initialized to at least a benign passthrough
-    _instanceCallback = instanceCallback ?? (o) => o;
+    _retrievalCallback = retrievalCallback ?? (o) => o;
 
     // register current Environments as lazy singleton
     if (!getIt.isRegistered<Set<String>>(instanceName: kEnvironmentsName)) {
@@ -48,12 +48,12 @@ class GetItHelper {
     dynamic param1,
     dynamic param2,
   }) =>
-      _instanceCallback(
-      getIt.get<T>(
-        instanceName: instanceName,
-        param1: param1,
-        param2: param2,
-      )) as T;
+      _retrievalCallback(
+        getIt.get<T>(
+          instanceName: instanceName,
+          param1: param1,
+          param2: param2,
+        )) as T;
 
   Future<T> getAsync<T extends Object>({
     String? instanceName,

--- a/injectable_generator/lib/code_builder/library_builder.dart
+++ b/injectable_generator/lib/code_builder/library_builder.dart
@@ -352,6 +352,7 @@ class InitMethodGenerator with SharedGeneratorCode {
         getInstanceRefer,
         refer('environment'),
         refer('environmentFilter'),
+        refer('instanceCallback'),
       ],
     );
 
@@ -393,7 +394,14 @@ class InitMethodGenerator with SharedGeneratorCode {
                 'EnvironmentFilter',
                 url: _injectableImport,
                 nullable: true,
-              ))
+              )),
+            Parameter((b) => b
+              ..named = true
+              ..name = 'instanceCallback'
+              ..type = nullableRefer(
+                'Object Function(Object)',
+                nullable: true,
+              )),
           ] else if (!isMicroPackage)
             Parameter((b) => b
               ..named = true

--- a/injectable_generator/lib/code_builder/library_builder.dart
+++ b/injectable_generator/lib/code_builder/library_builder.dart
@@ -352,7 +352,7 @@ class InitMethodGenerator with SharedGeneratorCode {
         getInstanceRefer,
         refer('environment'),
         refer('environmentFilter'),
-        refer('instanceCallback'),
+        refer('retrievalCallback'),
       ],
     );
 
@@ -397,7 +397,7 @@ class InitMethodGenerator with SharedGeneratorCode {
               )),
             Parameter((b) => b
               ..named = true
-              ..name = 'instanceCallback'
+              ..name = 'retrievalCallback'
               ..type = nullableRefer(
                 'Object Function(Object)',
                 nullable: true,


### PR DESCRIPTION
 An instance callback is a delegate function which will be invoked every time an instead is retrieved.

This is a simplified solution for feature request #405 
This solution requires minimal changes to the code, relying mainly on an alteration to getItHelper.
The alternative (more invasive) approach, is to alter the injectable_generator, to perform the wrapping when the instance is actually constructed, rather than just when it is retrieved.
However, for my needs, a callback for when the object is retrieved is sufficient.