### PR TITLE
Supports custom path for generated files

### DIFF
--- a/injectable_generator/lib/builder.dart
+++ b/injectable_generator/lib/builder.dart
@@ -13,7 +13,12 @@ Builder injectableBuilder(BuilderOptions options) {
 }
 
 Builder injectableConfigBuilder(BuilderOptions options) {
-  return LibraryBuilder(InjectableConfigGenerator(),
-      generatedExtension: '.config.dart',
-      additionalOutputExtensions: ['.module.dart']);
+  final generator = InjectableConfigGenerator();
+  if (options.config.containsKey("build_extensions")) {
+    return LibraryBuilder(generator, options: options);
+  } else {
+    return LibraryBuilder(generator,
+        generatedExtension: '.config.dart',
+        additionalOutputExtensions: ['.module.dart']);
+  }
 }

--- a/injectable_generator/lib/generators/injectable_config_generator.dart
+++ b/injectable_generator/lib/generators/injectable_config_generator.dart
@@ -177,7 +177,13 @@ class InjectableConfigGenerator extends GeneratorForAnnotation<InjectableInit> {
         DartFormatter().format(generatedLib.accept(emitter).toString());
 
     if (isMicroPackage) {
-      final outputId = buildStep.inputId.changeExtension('.module.dart');
+      final outputId = buildStep.allowedOutputs.firstWhereOrNull(
+        (element) => element.path.endsWith('.module.dart'),
+      );
+      if (outputId == null) {
+        throwBoxed(_invalidCustomBuildExtensionsMessage);
+        return;
+      }
       return buildStep.writeAsString(
         outputId,
         [
@@ -307,5 +313,15 @@ class InjectableConfigGenerator extends GeneratorForAnnotation<InjectableInit> {
         }
       }
     }
+  }
+
+  String get _invalidCustomBuildExtensionsMessage {
+    return '''Custom 'build_extensions' detected but the output for '.module.dart' not provided
+See an example of a valid build_extensions below:
+      ...
+        options:
+          build_extensions:
+            {'lib/{{}}.dart': ['lib/generated/{{}}.config.dart', 'lib/generated/{{}}.module.dart']}
+''';
   }
 }


### PR DESCRIPTION
This PR supports path customization for `.config.dart` and `.module.dart`.