### PR TITLE
handle and pass on exception for async scope initialization

### DIFF
--- a/injectable/lib/src/get_it_helper.dart
+++ b/injectable/lib/src/get_it_helper.dart
@@ -265,8 +265,12 @@ class GetItHelper {
     getIt.pushNewScope(
       scopeName: name,
       init: (getIt) async {
-        await init(this);
-        completer.complete(getIt);
+        try {
+          await init(this);
+          completer.complete(getIt);
+        } catch (e, s) {
+          completer.completeError(e, s);
+        }
       },
       dispose: dispose,
     );


### PR DESCRIPTION
This PR handles and passes exceptions that can happen inside the async scope initialization.
Previously the completer never completed if the init function threw an exception.