### PR TITLE
Singleton check for `_canRegister` before calling the class constructor (fix for #425)

### DIFF
--- a/injectable/lib/src/get_it_helper.dart
+++ b/injectable/lib/src/get_it_helper.dart
@@ -185,7 +185,7 @@ class GetItHelper {
   /// a conditional wrapper method for getIt.registerSingleton
   /// it only registers if [_canRegister] returns true
   void singleton<T extends Object>(
-    T instance, {
+    FactoryFunc<T> factoryFunc, {
     String? instanceName,
     bool? signalsReady,
     Set<String>? registerFor,
@@ -193,7 +193,7 @@ class GetItHelper {
   }) {
     if (_canRegister(registerFor)) {
       getIt.registerSingleton<T>(
-        instance,
+        factoryFunc(),
         instanceName: instanceName,
         signalsReady: signalsReady,
         dispose: dispose,
@@ -215,11 +215,10 @@ class GetItHelper {
     if (_canRegister(registerFor)) {
       if (preResolve) {
         return factoryFunc().then(
-          (instance) => singleton(
+          (instance) => getIt.registerSingleton<T>(
             instance,
             instanceName: instanceName,
             signalsReady: signalsReady,
-            registerFor: registerFor,
             dispose: dispose,
           ),
         );

--- a/injectable_generator/lib/code_builder/library_builder.dart
+++ b/injectable_generator/lib/code_builder/library_builder.dart
@@ -573,14 +573,12 @@ class InitMethodGenerator with SharedGeneratorCode {
 
   Code buildSingletonRegisterFun(DependencyConfig dep) {
     String funcReferName;
-    var asFactory = true;
     final hasAsyncDep = dependencies.hasAsyncDependency(dep);
     if (dep.isAsync || hasAsyncDep) {
       funcReferName = 'singletonAsync';
     } else if (dep.dependsOn.isNotEmpty) {
       funcReferName = 'singletonWithDependencies';
     } else {
-      asFactory = false;
       funcReferName = 'singleton';
     }
 
@@ -588,12 +586,10 @@ class InitMethodGenerator with SharedGeneratorCode {
         dep.isFromModule ? _buildInstanceForModule(dep) : _buildInstance(dep);
     final instanceBuilderCode = _buildInstanceBuilderCode(instanceBuilder, dep);
     final registerExpression = _ghLocalRefer.property(funcReferName).call([
-      asFactory
-          ? Method((b) => b
-            ..lambda = instanceBuilderCode is! Block
-            ..modifier = hasAsyncDep ? MethodModifier.async : null
-            ..body = instanceBuilderCode).closure
-          : CodeExpression(instanceBuilderCode)
+      Method((b) => b
+        ..lambda = instanceBuilderCode is! Block
+        ..modifier = hasAsyncDep ? MethodModifier.async : null
+        ..body = instanceBuilderCode).closure
     ], {
       if (dep.instanceName != null)
         'instanceName': literalString(dep.instanceName!),

--- a/injectable_generator/test/code_builder/eager_singleton_test.dart
+++ b/injectable_generator/test/code_builder/eager_singleton_test.dart
@@ -16,7 +16,7 @@ void main() {
             type: ImportableType(name: 'Demo'),
             typeImpl: ImportableType(name: 'Demo'),
           )),
-          'gh.singleton<Demo>(Demo());');
+          'gh.singleton<Demo>(() => Demo());');
     });
 
     test("Singleton generator abstract", () {
@@ -26,7 +26,7 @@ void main() {
           type: ImportableType(name: 'AbstractType'),
           typeImpl: ImportableType(name: 'Demo'),
         )),
-        'gh.singleton<AbstractType>(Demo());',
+        'gh.singleton<AbstractType>(() => Demo());',
       );
     });
 
@@ -38,7 +38,7 @@ void main() {
           typeImpl: ImportableType(name: 'Demo'),
           instanceName: 'MyDemo',
         )),
-        "gh.singleton<Demo>(Demo(), instanceName: 'MyDemo', );",
+        "gh.singleton<Demo>(() => Demo(), instanceName: 'MyDemo', );",
       );
     });
 
@@ -98,7 +98,7 @@ void main() {
               )
             ],
           )),
-          'gh.singleton<Demo>(Demo(gh<Storage>()));');
+          'gh.singleton<Demo>(() => Demo(gh<Storage>()));');
     });
 
     test("Singleton generator with async Positional dependencies", () {
@@ -143,7 +143,7 @@ void main() {
               )
             ],
           )),
-          'gh.singleton<Demo>(Demo(storage: gh<Storage>()));');
+          'gh.singleton<Demo>(() => Demo(storage: gh<Storage>()));');
     });
 
     test("Singleton generator with async named dependencies", () {
@@ -201,7 +201,7 @@ void main() {
         ),
       ];
       expect(generate(dep, allDeps: allDeps),
-          'gh.singleton<Demo>(Demo(storage: gh<Storage>(instanceName: \'storageImpl\')));');
+          'gh.singleton<Demo>(() => Demo(storage: gh<Storage>(instanceName: \'storageImpl\')));');
     });
   });
 }


### PR DESCRIPTION
When you register the singleton for a specific environment, its constructor is still called, even if the package will decide not to inject it by checking `_canRegister` method.

It's constructor needs to be called after all of the checks are passed, and the dependency will be injected.

This is a fix to #425

P.S. I see now that it is duplicate of #408, but the tests fixes are missing there 