### PR TITLE
Add generateForEnvironments option

### DIFF
--- a/injectable/example/lib/injector/injector_dev.config.dart
+++ b/injectable/example/lib/injector/injector_dev.config.dart
@@ -1,0 +1,66 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// InjectableConfigGenerator
+// **************************************************************************
+
+// ignore_for_file: type=lint
+// coverage:ignore-file
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:example/module/register_module.dart' as _i3;
+import 'package:example/services/abstract_service.dart' as _i4;
+import 'package:get_it/get_it.dart' as _i1;
+import 'package:injectable/injectable.dart' as _i2;
+
+const String _dev = 'dev';
+
+extension GetItInjectableX on _i1.GetIt {
+// initializes the registration of main-scope dependencies inside of GetIt
+  Future<_i1.GetIt> init({
+    String? environment,
+    _i2.EnvironmentFilter? environmentFilter,
+  }) async {
+    final gh = _i2.GetItHelper(
+      this,
+      environment,
+      environmentFilter,
+    );
+    final registerModule = _$RegisterModule();
+    gh.singleton<_i3.DisposableSingleton>(
+      () => _i3.DisposableSingleton(),
+      dispose: (i) => i.dispose(),
+    );
+    gh.singleton<_i4.ConstService>(() => const _i4.ConstService());
+    gh.factoryParam<_i4.IService, String?, dynamic>(
+      (
+        param,
+        _,
+      ) =>
+          _i4.ServiceImpl(param),
+      instanceName: 'ServiceImpl',
+      registerFor: {_dev},
+    );
+    gh.factory<_i4.Model>(() => _i4.ModelX());
+    await gh.factoryAsync<_i4.AbstractService>(
+      () => _i4.AsyncService.create(
+          gh<Set<String>>(instanceName: '__environments__')),
+      registerFor: {_dev},
+      preResolve: true,
+    );
+    gh.lazySingletonAsync<_i3.Repo>(
+      () =>
+          registerModule.getRepo(gh<_i4.IService>(instanceName: 'ServiceImpl')),
+      instanceName: 'Repo',
+      registerFor: {_dev},
+      dispose: _i3.disposeRepo,
+    );
+    gh.singletonAsync<_i4.PostConstructableService>(() {
+      final i = _i4.PostConstructableService(gh<_i4.IService>());
+      return i.init().then((_) => i);
+    });
+    return this;
+  }
+}
+
+class _$RegisterModule extends _i3.RegisterModule {}

--- a/injectable/example/lib/injector/injector_dev.dart
+++ b/injectable/example/lib/injector/injector_dev.dart
@@ -1,0 +1,16 @@
+import 'package:get_it/get_it.dart';
+import 'package:injectable/injectable.dart';
+
+import 'injector_dev.config.dart';
+
+@InjectableInit(preferRelativeImports: false, generateForEnvironments: {dev})
+configDevInjector(
+  GetIt getIt, {
+  String? env,
+  EnvironmentFilter? environmentFilter,
+}) {
+  return getIt.init(
+    environmentFilter: environmentFilter,
+    environment: env,
+  );
+}

--- a/injectable/lib/src/injectable_annotations.dart
+++ b/injectable/lib/src/injectable_annotations.dart
@@ -78,6 +78,11 @@ class InjectableInit {
   /// defaults to false
   final bool usesConstructorCallback;
 
+  /// a Set of environments to generate for.
+  /// if not provided, code for all environments will be generated.
+  /// defaults to empty
+  final Set<Environment> generateForEnvironments;
+
   /// default constructor
   const InjectableInit({
     this.generateForDir = const ['lib'],
@@ -93,6 +98,7 @@ class InjectableInit {
     this.externalPackageModulesAfter,
     this.externalPackageModulesBefore,
     this.usesConstructorCallback = false,
+    this.generateForEnvironments = const {},
   }) : _isMicroPackage = false;
 
   /// default constructor
@@ -106,6 +112,7 @@ class InjectableInit {
     this.throwOnMissingDependencies = false,
     this.ignoreUnregisteredTypesInPackages = const [],
     this.usesNullSafety = true,
+    this.generateForEnvironments = const {},
   })  : _isMicroPackage = true,
         asExtension = false,
         includeMicroPackages = false,

--- a/injectable_generator/lib/generators/injectable_config_generator.dart
+++ b/injectable_generator/lib/generators/injectable_config_generator.dart
@@ -38,6 +38,10 @@ class InjectableConfigGenerator extends GeneratorForAnnotation<InjectableInit> {
     final targetFile = element.source?.uri;
     final preferRelativeImports =
         annotation.read("preferRelativeImports").boolValue;
+    final generateForEnvironments = annotation
+        .read('generateForEnvironments')
+        .setValue
+        .map((e) => e.getField('name')?.toStringValue());
 
     final includeMicroPackages =
         annotation.read("includeMicroPackages").boolValue;
@@ -153,9 +157,16 @@ class InjectableConfigGenerator extends GeneratorForAnnotation<InjectableInit> {
         'Dependencies of type [${entry.key.$1}] must either all be async or all be sync\n',
       );
     }
-
+    final filteredDeps = generateForEnvironments.isEmpty
+        ? deps
+        : deps
+            .where((element) =>
+                element.environments.isEmpty ||
+                element.environments
+                    .any((e) => generateForEnvironments.contains(e)))
+            .toList();
     final generator = LibraryGenerator(
-      dependencies: List.of(deps),
+      dependencies: List.of(filteredDeps),
       targetFile: preferRelativeImports ? targetFile : null,
       initializerName: initializerName,
       asExtension: asExtension,


### PR DESCRIPTION
Tree shaking is critically important in large-scale projects. I was reading #181 and the last proposition in the conversation sounded reasonable, so I implemented it by adding a `generateForEnvironment` parameter to the `InjectableInit` constructor. That allows us to create an `initDI` function per environment or set of environments (I've added a `configDevInjector` in the `example` to illustrate what the user experience might look like). A similar idea was mentioned in #191. From what I see, it fixes #181.

What do you think of this approach?