### PR TITLE
chore: unpin meta

### DIFF
--- a/injectable/pubspec.yaml
+++ b/injectable/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   get_it: ">=7.2.0 <8.0.0"
-  meta: 1.11.0
+  meta: ^1.11.0
 
 dev_dependencies:
   lints: ^3.0.0


### PR DESCRIPTION
Hi there!
I don't know which implications this has for flutter_test as mentioned in https://github.com/Milad-Akarie/injectable/commit/00974a83a8f22fd1150f4e4873e70bad802cc9ae, but flutter 3.22 pins meta to 1.12.0, which renders this package unusable (see also https://github.com/Milad-Akarie/injectable/issues/462) with the latest version