### PR TITLE
Improve Code Generation using hash in alias imports.

### DIFF
--- a/injectable_generator/lib/generators/injectable_config_generator.dart
+++ b/injectable_generator/lib/generators/injectable_config_generator.dart
@@ -310,6 +310,9 @@ class InjectableConfigGenerator extends GeneratorForAnnotation<InjectableInit> {
   }
 }
 
+/// The reason to use this allocator is to avoid changing in the alias of the imports
+/// With this allocator, we can hash the url of the import and use it as an alias
+/// This will make sure that the alias is consistent across multiple runs avoiding conflicts
 class _HashedAllocator implements Allocator {
   static const _doNotPrefix = ['dart:core'];
 


### PR DESCRIPTION
This will close https://github.com/Milad-Akarie/injectable/issues/440

With `_HashedAllocator` we will have consistent alias across multiple generations independent of how many imports we will have.

With this fix, we can reduce the merge conflicts working with `injectable` across multiple branches. 