### PR TITLE
feat: Update TargetKind on Scope

### DIFF
--- a/injectable/lib/src/injectable_annotations.dart
+++ b/injectable/lib/src/injectable_annotations.dart
@@ -379,7 +379,7 @@ const order = Order(0);
 
 /// Used to annotate dependencies which are
 /// registered under a different scope than main-scope
-@Target({TargetKind.classType})
+@Target({TargetKind.classType, TargetKind.method, TargetKind.getter})
 class Scope {
   /// name of the scope
   final String name;


### PR DESCRIPTION
Updating from `injectable 2.3.2` to the latest version has broken my app. Seems like `Scope` annotation needs some more `TargetKind`s added to it.