### PR TITLE
Fix dependency sort when dependencies have multiple environments

### DIFF
--- a/injectable_generator/lib/code_builder/builder_utils.dart
+++ b/injectable_generator/lib/code_builder/builder_utils.dart
@@ -109,11 +109,25 @@ void _sortByDependents(
         if (iDep.isFactoryParam) {
           return true;
         }
-        // if dep is already in sorted return true
-        if (lookupDependencyWithNoEnvOrHasAny(iDep, sorted, dep.environments) !=
+
+        /// for empty environments we check to see if all the dependencies from
+        /// all the environments are already in sorted
+        if (dep.environments.isEmpty) {
+          final List<DependencyConfig> deps = unSorted
+              .where((d) =>
+          d.type == iDep.type && d.instanceName == iDep.instanceName)
+              .toList(growable: false);
+
+          if (deps.every(sorted.contains)) {
+            return true;
+          }
+        } else if (lookupDependencyWithNoEnvOrHasAny(
+            iDep, sorted, dep.environments) !=
             null) {
+          // if dep is already in sorted return true
           return true;
         }
+
         // if dep is in unSorted we skip it in this iteration, if not we include it
         return lookupDependencyWithNoEnvOrHasAny(
                 iDep, unSorted, dep.environments) ==

--- a/injectable_generator/lib/models/dependency_config.dart
+++ b/injectable_generator/lib/models/dependency_config.dart
@@ -54,13 +54,16 @@ class DependencyConfig {
   });
 
   // used for testing
-  factory DependencyConfig.factory(String type,
-      {List<String> deps = const [],
-      List<String> envs = const [],
-      int order = 0}) {
+  factory DependencyConfig.factory(
+    String type, {
+    String? typeImpl,
+    List<String> deps = const [],
+    List<String> envs = const [],
+    int order = 0,
+  }) {
     return DependencyConfig(
-      type: ImportableType(name: type),
-      typeImpl: ImportableType(name: type),
+      type: ImportableType(name: type, import: type),
+      typeImpl: ImportableType(name: typeImpl ?? type),
       environments: envs,
       orderPosition: order,
       dependencies: deps
@@ -75,12 +78,19 @@ class DependencyConfig {
   }
 
   // used for testing
-  factory DependencyConfig.singleton(String type,
-      {List<String> deps = const [], int order = 0}) {
+  factory DependencyConfig.singleton(
+    String type, {
+    String? typeImpl,
+    List<String> deps = const [],
+    List<String> envs = const [],
+    int order = 0,
+    bool lazy = false,
+  }) {
     return DependencyConfig(
       type: ImportableType(name: type),
-      typeImpl: ImportableType(name: type),
+      typeImpl: ImportableType(name: typeImpl ?? type),
       injectableType: InjectableType.singleton,
+      environments: envs,
       orderPosition: order,
       dependencies: deps
           .map(

--- a/injectable_generator/lib/models/dependency_config.dart
+++ b/injectable_generator/lib/models/dependency_config.dart
@@ -89,7 +89,8 @@ class DependencyConfig {
     return DependencyConfig(
       type: ImportableType(name: type),
       typeImpl: ImportableType(name: typeImpl ?? type),
-      injectableType: InjectableType.singleton,
+      injectableType:
+          lazy ? InjectableType.lazySingleton : InjectableType.singleton,
       environments: envs,
       orderPosition: order,
       dependencies: deps

--- a/injectable_generator/test/code_builder/builder_utils_test.dart
+++ b/injectable_generator/test/code_builder/builder_utils_test.dart
@@ -37,6 +37,22 @@ void main() {
       expect(sortDependencies(deps), expectedResult);
     });
 
+    test('should sort as [Dio,FakeUserApi,UserApi,UserRepository]', () {
+      final deps = [
+        DependencyConfig.singleton('Repository', deps: ['UserApi']),
+        DependencyConfig.singleton('UserApi', typeImpl: 'FakeUserApi', envs: ['test'], lazy: true),
+        DependencyConfig.singleton('UserApi', typeImpl: 'ImplUserApi', envs: ['dev'], deps: ['Dio']),
+        DependencyConfig.singleton('Dio', lazy: true, envs: ['dev']),
+      ];
+      final expectedResult = [
+        DependencyConfig.singleton('Dio', lazy: true, envs: ['dev']),
+        DependencyConfig.singleton('UserApi', typeImpl: 'FakeUserApi', envs: ['test'], lazy: true),
+        DependencyConfig.singleton('UserApi', typeImpl: 'ImplUserApi', envs: ['dev'], deps: ['Dio']),
+        DependencyConfig.singleton('Repository', deps: ['UserApi']),
+      ];
+      expect(sortDependencies(deps).toList(), expectedResult);
+    });
+
     test('should sort as [A,B]', () {
       final deps = [
         DependencyConfig.factory('AppServiceUser', deps: ['Service']),


### PR DESCRIPTION
Hello, right now there is an issue regarding the order the dependencies are registered when using multiple environments.

Let's say we have a class UserApi which we annotate with @dev, then we create another class FakeUserApi which implements UserApi, we register that class as UserApi and annotate it with @test. Now we have a class UserRepository in which we inject UserApi. Now UserRepository has no environments annotated to it so in locator.config.dart there might be a case where the registrations would be in this order FakeUserApi then UserRepository then UserApi.