### PR TITLE
Add polymorphism for modules

### DIFF
--- a/injectable_generator/lib/generators/injectable_generator.dart
+++ b/injectable_generator/lib/generators/injectable_generator.dart
@@ -7,6 +7,7 @@ import 'package:injectable/injectable.dart';
 import 'package:injectable_generator/models/dependency_config.dart';
 import 'package:injectable_generator/resolvers/dependency_resolver.dart';
 import 'package:injectable_generator/resolvers/importable_type_resolver.dart';
+import 'package:injectable_generator/resolvers/executable_resolver.dart';
 import 'package:injectable_generator/utils.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -39,10 +40,7 @@ class InjectableGenerator implements Generator {
           '[${clazz.name}] must be an abstract class!',
           element: clazz,
         );
-        final executables = <ExecutableElement>[
-          ...clazz.accessors,
-          ...clazz.methods,
-        ];
+        final executables = ExecutableResolver.getAllExecutables(clazz);
         for (var element in executables) {
           if (element.isPrivate) continue;
           allDepsInStep.add(

--- a/injectable_generator/lib/resolvers/executable_resolver.dart
+++ b/injectable_generator/lib/resolvers/executable_resolver.dart
@@ -1,0 +1,54 @@
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+
+class ExecutableResolver {
+  static List<ExecutableElement> getAllExecutables(ClassElement clazz) {
+    final Set<String> seenMethods = {};
+    final Set<String> seenAccessors = {};
+
+    final List<ExecutableElement> methods = [];
+    final List<PropertyAccessorElement> accessors = [];
+
+    InterfaceType? type = clazz.thisType;
+
+    while (type != null) {
+      if (type.element.library.isDartCore) {
+        break;
+      }
+
+      for (final method in type.element.methods) {
+        if (!method.isSynthetic && seenMethods.add(method.name)) {
+          methods.add(method);
+        }
+      }
+
+      for (final accessor in type.element.accessors) {
+        if (!accessor.isSynthetic && seenAccessors.add(accessor.name)) {
+          accessors.add(accessor);
+        }
+      }
+
+      type = type.superclass;
+    }
+
+    for (final mixin in clazz.mixins) {
+      for (final method in mixin.element.methods) {
+        if (!method.isSynthetic && seenMethods.add(method.name)) {
+          methods.add(method);
+        }
+      }
+
+      for (final accessor in mixin.element.accessors) {
+        if (!accessor.isSynthetic && seenAccessors.add(accessor.name)) {
+          accessors.add(accessor);
+        }
+      }
+    }
+
+    return [
+      ...accessors,
+      ...methods,
+    ];
+  }
+}


### PR DESCRIPTION
`@module` annotated class members not read by the generator. This fix/feature allows that. I faced this issue when I created a shared module with base dependencies for my projects. 