### PR TITLE
Add documentation and examples for generateAccessors

### DIFF
--- a/injectable/example/bin/main.dart
+++ b/injectable/example/bin/main.dart
@@ -7,5 +7,30 @@ GetIt getIt = GetIt.instance;
 
 void main() async {
   await getIt.init(environment: Environment.dev);
+
+  // Example 1: Basic service without parameters
+  print('=== Basic Service ===');
   print(getIt<IService>());
+
+  // Example 2: Service with factory parameters - Using standard syntax
+  print('\n=== Service with Factory Parameters (Standard Syntax) ===');
+  final service1 = getIt.get<ConfigurableService>(
+    param1: 'sk-12345',
+    param2: 'https://api.example.com',
+  );
+  print(service1);
+
+  // Example 3: Service with factory parameters - Using accessor methods
+  print('\n=== Service with Factory Parameters (Accessor Methods) ===');
+  final service2 = getIt.configurableService(
+    apiKey: 'sk-67890',
+    baseUrl: 'https://api.example.org',
+  );
+  print(service2);
+
+  // Example 4: Service with single parameter
+  print('\n=== Service with Single Parameter ===');
+  final logger = getIt.loggerService(name: 'MyApp');
+  logger.log('Application started');
 }
+

--- a/injectable/example/lib/injector/injector.config.dart
+++ b/injectable/example/lib/injector/injector.config.dart
@@ -39,6 +39,9 @@ extension GetItInjectableX on _i174.GetIt {
       ),
       registerFor: {_platformMobile},
     );
+    gh.factoryParam<_i978.LoggerService, String, dynamic>(
+      (name, _) => _i978.LoggerService(name),
+    );
     gh.factoryAsync<_i253.Repo>(
       () => _i253.Repo.asyncRepo(gh<_i978.IService>()),
     );
@@ -63,6 +66,10 @@ extension GetItInjectableX on _i174.GetIt {
       instanceName: 'WebService',
       registerFor: {_platformWeb},
     );
+    gh.factoryParam<_i978.ConfigurableService, String, String>(
+      (apiKey, baseUrl) =>
+          _i978.ConfigurableService(apiKey: apiKey, baseUrl: baseUrl),
+    );
     return this;
   }
 
@@ -77,6 +84,9 @@ extension GetItInjectableX on _i174.GetIt {
 
   _i978.MobileService get mobileService => get<_i978.MobileService>();
 
+  _i978.LoggerService loggerService({required String name}) =>
+      get<_i978.LoggerService>(param1: name);
+
   Future<_i253.Repo> get repo => getAsync<_i253.Repo>();
 
   Future<_i978.PostConstructableService> get postConstructableService =>
@@ -86,6 +96,11 @@ extension GetItInjectableX on _i174.GetIt {
 
   _i978.WebService webService({String? instanceName}) =>
       get<_i978.WebService>(instanceName: instanceName);
+
+  _i978.ConfigurableService configurableService({
+    required String apiKey,
+    required String baseUrl,
+  }) => get<_i978.ConfigurableService>(param1: apiKey, param2: baseUrl);
 }
 
 class _$RegisterModule extends _i253.RegisterModule {}

--- a/injectable/example/lib/injector/injector_dev.config.dart
+++ b/injectable/example/lib/injector/injector_dev.config.dart
@@ -31,6 +31,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.singleton<_i978.ConstService>(() => const _i978.ConstService());
     gh.factory<_i978.IService>(() => _i978.ServiceImpl());
     gh.factoryCached<_i978.Model>(() => _i978.ModelX());
+    gh.factoryParam<_i978.LoggerService, String, dynamic>(
+      (name, _) => _i978.LoggerService(name),
+    );
     gh.factoryAsync<_i253.Repo>(
       () => _i253.Repo.asyncRepo(gh<_i978.IService>()),
     );
@@ -49,6 +52,10 @@ extension GetItInjectableX on _i174.GetIt {
       () => registerModule.getRepo(gh<_i978.IService>()),
       instanceName: 'Repo',
       dispose: _i253.disposeRepo,
+    );
+    gh.factoryParam<_i978.ConfigurableService, String, String>(
+      (apiKey, baseUrl) =>
+          _i978.ConfigurableService(apiKey: apiKey, baseUrl: baseUrl),
     );
     return this;
   }

--- a/injectable/example/lib/services/abstract_service.dart
+++ b/injectable/example/lib/services/abstract_service.dart
@@ -77,3 +77,31 @@ sealed class Model {
 class ModelX extends Model {}
 
 class ModelY extends Model {}
+
+/// Example of a service that accepts factory parameters
+@injectable
+class ConfigurableService {
+  final String apiKey;
+  final String baseUrl;
+
+  ConfigurableService({
+    @factoryParam required this.apiKey,
+    @factoryParam required this.baseUrl,
+  });
+
+  @override
+  String toString() => 'ConfigurableService(apiKey: $apiKey, baseUrl: $baseUrl)';
+}
+
+/// Example of a service with a single parameter
+@injectable
+class LoggerService {
+  final String name;
+
+  LoggerService(@factoryParam this.name);
+
+  void log(String message) {
+    print('[$name] $message');
+  }
+}
+


### PR DESCRIPTION
Last week I proposed a [feature](https://github.com/Milad-Akarie/injectable/issues/533) which I just found out already exists.

`generateAccessors` is not covered in the documentation causing me to have completely missed it.
I only figured it out after I was trying to contribute it myself 😅 .

So instead of making a PR to add the functionality, it became a PR about adding documentation and examples.

closes #533 
