### PR TITLE
Fixes #532: treat external deps as non-blocking in env sort

### DIFF
--- a/injectable_generator/lib/code_builder/builder_utils.dart
+++ b/injectable_generator/lib/code_builder/builder_utils.dart
@@ -130,11 +130,15 @@ void _sortByDependents(
       } else {
         int foundForEnvs = 0;
         for (final env in dep.environments) {
-          if (lookupDependencyWithNoEnvOrHasAny(iDep, sorted, [env]) == null) {
-            return false;
-          } else {
+          if (lookupDependencyWithNoEnvOrHasAny(iDep, sorted, [env]) != null ||
+              // External/unregistered deps are resolved by parent packages and
+              // should not block local sorting.
+              (lookupDependency(iDep, unSorted) == null &&
+                  lookupDependency(iDep, sorted) == null)) {
             foundForEnvs++;
+            continue;
           }
+          return false;
         }
         // if all deps for all environments are found we can proceed
         if (foundForEnvs == dep.environments.length) {

--- a/injectable_generator/test/code_builder/builder_utils_test.dart
+++ b/injectable_generator/test/code_builder/builder_utils_test.dart
@@ -1269,6 +1269,45 @@ void main() {
       },
     );
 
+    test(
+      'should terminate sorting when a no-env dependency waits on an unsortable env variant',
+      () {
+        final dep1 = DependencyConfig.factory(
+          'Service',
+          typeImpl: 'ProdService',
+          envs: ['prod'],
+          deps: ['ExternalDependency'],
+        );
+        final dep2 = DependencyConfig.factory(
+          'Service',
+          typeImpl: 'DevService',
+          envs: ['dev'],
+        );
+        final consumer = DependencyConfig.factory(
+          'Consumer',
+          deps: ['Service'],
+        );
+        final deps = [consumer, dep1, dep2];
+
+        expect(
+          lookupDependency(
+            InjectedDependency(
+              type: const ImportableType(name: 'ExternalDependency'),
+              paramName: 'externalDependency',
+            ),
+            deps,
+          ),
+          isNull,
+        );
+        final result = sortDependencies(deps);
+
+        expect(result, unorderedEquals(deps));
+        final consumerIndex = result.indexOf(consumer);
+        expect(result.indexOf(dep1), lessThan(consumerIndex));
+        expect(result.indexOf(dep2), lessThan(consumerIndex));
+      },
+    );
+
     test('should handle partial environment matches - not all envs found', () {
       final dep1 = DependencyConfig(
         type: const ImportableType(name: 'Config'),


### PR DESCRIPTION
fixes #532
 
This treats external/unregistered dependencies as non-blocking in the env-specific `_sortByDependents` path.
 
Without this, a no-env dependency can wait forever on an env-specific implementation that depends on a type registered in a parent/shared package, which leads to infinite recursion/stack-overflow 
overflow during sorting.
 
Added a regression test.
 
