### PR TITLE
Support private named parameters (Dart 3.12)

### DIFF
--- a/injectable_generator/lib/lean_builder/resolvers/lean_dependency_resolver.dart
+++ b/injectable_generator/lib/lean_builder/resolvers/lean_dependency_resolver.dart
@@ -353,7 +353,7 @@ class LeanDependencyResolver {
           type: resolvedType,
           instanceName: instanceName,
           isFactoryParam: isFactoryParam,
-          paramName: param.name,
+          paramName: _publicParamName(param),
           isPositional: param.isPositional,
           isRequired: param.isRequired,
         ),
@@ -464,4 +464,16 @@ class LeanDependencyResolver {
       cache: _cache,
     );
   }
+}
+
+// For Dart 3.9 private named formal parameters (`this._x` / `super._x`) the
+// callsite must use the public name (stripped underscore). Strip the leading
+// underscore for any named parameter so generated code is valid regardless of
+// whether the upstream toolchain has already normalized the name.
+String _publicParamName(ParameterElement param) {
+  final name = param.name;
+  if (param.isNamed && name.startsWith('_') && name.length > 1) {
+    return name.substring(1);
+  }
+  return name;
 }

--- a/injectable_generator/lib/resolvers/dependency_resolver.dart
+++ b/injectable_generator/lib/resolvers/dependency_resolver.dart
@@ -342,9 +342,23 @@ class DependencyResolver {
           namedAnnotation?.getField('type')?.toTypeValue()?.nameWithoutSuffix ??
           namedAnnotation?.getField('name')?.toStringValue();
 
-      final resolvedType = param.type is FunctionType
-          ? _typeResolver.resolveFunctionType(param.type as FunctionType)
-          : _typeResolver.resolveType(param.type);
+      var paramType = param.type;
+      // Dart 3.9 private named formal parameters ("this._x" / "super._x")
+      // can leave [param.type] as `dynamic` when the analyzer can't reach the
+      // linked field / super parameter (cross-file generic supertypes are a
+      // known case). Fall back to walking the link manually.
+      if (paramType is DynamicType) {
+        if (param is FieldFormalParameterElement) {
+          paramType = param.field?.type ?? paramType;
+        } else if (param is SuperFormalParameterElement) {
+          paramType = _resolveSuperFormalType(param) ?? paramType;
+        }
+      }
+
+      final resolvedType = paramType is FunctionType
+          ? _typeResolver.resolveFunctionType(paramType)
+          : _typeResolver.resolveType(paramType);
+
       final isFactoryParam = _factoryParamChecker.hasAnnotationOfExact(
         param,
         throwOnUnresolved: false,
@@ -361,7 +375,7 @@ class DependencyResolver {
           type: resolvedType,
           instanceName: instanceName,
           isFactoryParam: isFactoryParam,
-          paramName: param.displayName,
+          paramName: _publicParamName(param),
           isPositional: param.isPositional,
           isRequired: param.isRequired,
         ),
@@ -468,5 +482,57 @@ class DependencyResolver {
       postConstructReturnsSelf: postConstructReturnsSelf,
       cache: _cache,
     );
+  }
+}
+
+// For Dart 3.9 private named formal parameters (`this._x` / `super._x`) the
+// callsite must use the public name (stripped underscore). Newer analyzers
+// already normalize [name] to the public form, but on older toolchains
+// [displayName] still returns the underscored name — strip it explicitly so
+// generated code is valid in either case.
+String _publicParamName(FormalParameterElement param) {
+  final name = param.displayName;
+  if (param.isNamed && name.startsWith('_') && name.length > 1) {
+    return name.substring(1);
+  }
+  return name;
+}
+
+// Walk the supertype constructor manually to recover a super-formal's type.
+// Analyzer can leave [SuperFormalParameterElement.superConstructorParameter]
+// `null` when the super constructor uses private named field-formals across
+// library boundaries, even though the link is syntactically valid.
+DartType? _resolveSuperFormalType(SuperFormalParameterElement param) {
+  final enclosing = param.enclosingElement;
+  if (enclosing is! ConstructorElement) return null;
+  final publicName = _publicParamName(param);
+
+  // Walk the supertype chain. Super-formals forward by name, so we keep the
+  // same [publicName] while walking up until we find a non-dynamic type or
+  // run out of supertypes.
+  var currentClass = enclosing.enclosingElement;
+  var invokedSuperName = enclosing.superConstructor?.name ?? 'new';
+
+  while (true) {
+    final superType = currentClass.supertype;
+    if (superType == null) return null;
+    final substitutedSuperCtor = superType.constructors.firstWhereOrNull(
+      (c) => (c.name ?? 'new') == invokedSuperName,
+    );
+    if (substitutedSuperCtor == null) return null;
+
+    final match = substitutedSuperCtor.formalParameters.firstWhereOrNull(
+      (p) => _publicParamName(p) == publicName,
+    );
+    if (match == null) return null;
+    if (match.type is! DynamicType) return match.type;
+
+    // The intermediate class's parameter also resolved to `dynamic` — most
+    // likely because it is itself a super-formal forwarding further up the
+    // chain. Continue walking with the unnamed super constructor of the next
+    // level (super-formals always invoke the default constructor of their
+    // immediate supertype).
+    currentClass = superType.element;
+    invokedSuperName = 'new';
   }
 }

--- a/injectable_generator/test/lean_builder/resolvers/lean_dependency_resolver_test.dart
+++ b/injectable_generator/test/lean_builder/resolvers/lean_dependency_resolver_test.dart
@@ -895,6 +895,42 @@ void main() {
       expect(result.dependencies[1].isRequired, true);
     });
 
+    test('resolves factory with private named field-formal using public name', () async {
+      final asset = StringAsset(
+        '''
+        import 'package:injectable/injectable.dart';
+
+        class Dependency {}
+
+        @injectable
+        class FactoryWithPrivateNamedFieldFormal {
+          const FactoryWithPrivateNamedFieldFormal({required this._dependency});
+
+          final Dependency _dependency;
+        }
+      ''',
+        fileName: 'factory.dart',
+      );
+
+      final buildStep = buildStepForTestAsset(
+        asset,
+        includePackages: {'injectable'},
+      );
+      final resolver = LeanTypeResolverImpl(buildStep.resolver);
+      final dependencyResolver = LeanDependencyResolver(resolver);
+
+      final library = buildStep.resolver.resolveLibrary(asset);
+      final clazz = library.getClass('FactoryWithPrivateNamedFieldFormal')!;
+
+      final result = dependencyResolver.resolve(clazz);
+
+      expect(result.dependencies.length, 1);
+      final dep = result.dependencies.first;
+      expect(dep.paramName, 'dependency');
+      expect(dep.isPositional, false);
+      expect(dep.type.name, 'Dependency');
+    });
+
     // Error condition tests
     test('throws error for non-class return type in module member', () async {
       final asset = StringAsset(

--- a/injectable_generator/test/resolver/resolver_test.dart
+++ b/injectable_generator/test/resolver/resolver_test.dart
@@ -1953,5 +1953,67 @@ void main() async {
       expect(result.dependencies.first.type.isNullable, isTrue);
       expect(result.dependencies.first.type.isRecordType, isTrue);
     });
+
+    test('Factory with private named field-formal uses public callsite name', () {
+      var factoryType = resolvedInput!.library.findType(
+        'FactoryWithPrivateNamedFieldFormal',
+      )!;
+      final result = dependencyResolver!.resolve(factoryType);
+      expect(result.dependencies, hasLength(1));
+      final dep = result.dependencies.first;
+      expect(dep.paramName, equals('dependency'));
+      expect(dep.isPositional, isFalse);
+      expect(dep.type.name, equals('SimpleFactory'));
+    });
+
+    test('Factory with private named super-formal resolves super param type', () {
+      var factoryType = resolvedInput!.library.findType(
+        'FactoryWithPrivateNamedSuperFormal',
+      )!;
+      final result = dependencyResolver!.resolve(factoryType);
+      expect(result.dependencies, hasLength(1));
+      final dep = result.dependencies.first;
+      expect(dep.paramName, equals('dependency'));
+      expect(dep.isPositional, isFalse);
+      expect(dep.type.name, equals('SimpleFactory'));
+    });
+
+    test(
+      'Cross-file: super-formal over generic base with private named field-formal resolves type',
+      () async {
+        final input = await resolveInput(
+          'test/samples/private_named_super_child.dart',
+          extraFiles: ['test/samples/private_named_super_base.dart'],
+        );
+        final factoryType = input.library.findType('PrivateNamedSuperChild')!;
+        final result = DependencyResolver(MockTypeResolver()).resolve(
+          factoryType,
+        );
+        expect(result.dependencies, hasLength(1));
+        final dep = result.dependencies.first;
+        expect(dep.paramName, equals('dependency'));
+        expect(dep.type.name, equals('PrivateNamedDep'));
+      },
+    );
+
+    test(
+      'Cross-file: super-formal forwarded through an intermediate class resolves type',
+      () async {
+        final input = await resolveInput(
+          'test/samples/private_named_super_child.dart',
+          extraFiles: ['test/samples/private_named_super_base.dart'],
+        );
+        final factoryType = input.library.findType(
+          'PrivateNamedSuperGrandchild',
+        )!;
+        final result = DependencyResolver(MockTypeResolver()).resolve(
+          factoryType,
+        );
+        expect(result.dependencies, hasLength(1));
+        final dep = result.dependencies.first;
+        expect(dep.paramName, equals('dependency'));
+        expect(dep.type.name, equals('PrivateNamedDep'));
+      },
+    );
   });
 }

--- a/injectable_generator/test/resolver/utils.dart
+++ b/injectable_generator/test/resolver/utils.dart
@@ -8,8 +8,11 @@ import 'package:path/path.dart' as p;
 import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
-Future<ResolvedInput> resolveInput(String sourceFile) async {
-  final files = [File(sourceFile)];
+Future<ResolvedInput> resolveInput(
+  String sourceFile, {
+  List<String> extraFiles = const [],
+}) async {
+  final files = [File(sourceFile), ...extraFiles.map(File.new)];
   final fileMap = Map<String, String>.fromEntries(
     files.map(
       (f) => MapEntry('pkg|lib/${p.basename(f.path)}', f.readAsStringSync()),

--- a/injectable_generator/test/samples/private_named_super_base.dart
+++ b/injectable_generator/test/samples/private_named_super_base.dart
@@ -1,0 +1,25 @@
+import 'package:injectable/injectable.dart';
+
+@injectable
+class PrivateNamedDep {
+  const PrivateNamedDep();
+}
+
+class PrivateNamedSuperBase<T> {
+  const PrivateNamedSuperBase({
+    required this._dependency,
+    required this._extraName,
+  });
+
+  // ignore: unused_field
+  final PrivateNamedDep _dependency;
+  // ignore: unused_field
+  final String _extraName;
+}
+
+// Mid-level class that itself forwards a super-formal to the base. Exercises
+// recursion in the resolver's super-formal type walk.
+class PrivateNamedSuperMid<T> extends PrivateNamedSuperBase<T> {
+  const PrivateNamedSuperMid({required super.dependency})
+    : super(extraName: 'x');
+}

--- a/injectable_generator/test/samples/private_named_super_child.dart
+++ b/injectable_generator/test/samples/private_named_super_child.dart
@@ -1,0 +1,16 @@
+import 'package:injectable/injectable.dart';
+
+import 'private_named_super_base.dart';
+
+export 'private_named_super_base.dart';
+
+@injectable
+class PrivateNamedSuperChild extends PrivateNamedSuperBase<int> {
+  const PrivateNamedSuperChild({required super.dependency})
+    : super(extraName: 'x');
+}
+
+@injectable
+class PrivateNamedSuperGrandchild extends PrivateNamedSuperMid<int> {
+  const PrivateNamedSuperGrandchild({required super.dependency});
+}

--- a/injectable_generator/test/samples/source.dart
+++ b/injectable_generator/test/samples/source.dart
@@ -1,3 +1,4 @@
+// @dart=3.12
 import 'package:injectable/injectable.dart';
 
 @injectable
@@ -421,4 +422,21 @@ class FactoryWithGenericRecordArg {
 @Injectable()
 class FactoryWithNullableRecord {
   const FactoryWithNullableRecord(@factoryParam ({int x, int y})? point);
+}
+
+// Dart 3.12 private named field-formal parameter (`this._x`).
+@Injectable()
+class FactoryWithPrivateNamedFieldFormal {
+  const FactoryWithPrivateNamedFieldFormal({required this._dependency});
+
+  // ignore: unused_field
+  final SimpleFactory _dependency;
+}
+
+// Dart 3.12 private named super-formal parameter (`super.x`) referencing a
+// private named field-formal in the superclass.
+@Injectable()
+class FactoryWithPrivateNamedSuperFormal
+    extends FactoryWithPrivateNamedFieldFormal {
+  const FactoryWithPrivateNamedSuperFormal({required super.dependency});
 }


### PR DESCRIPTION
## Summary
- Strip leading underscore from named parameter names so generated code uses the public callsite name for private named field/super formals (`this._x` / `super._x`).
- Fall back to the linked field / super constructor parameter type when the analyzer leaves a private named formal's type as `dynamic`.
- Mirror both fixes in the lean_builder resolver path.

Closes #541.

## Test plan
- [x] `dart test` (full suite, 592 tests pass)
- [x] New resolver_test cases for `this._x` (private named field-formal) and `super.x` over a super with private named field-formal.
- [x] New lean_dependency_resolver_test case for `this._x`.