### PR TITLE
fix: avoid import alias collisions in HashedAllocator

### DIFF
--- a/injectable_generator/lib/code_builder/allocator.dart
+++ b/injectable_generator/lib/code_builder/allocator.dart
@@ -7,6 +7,7 @@ class HashedAllocator implements Allocator {
   static const _doNotPrefix = ['dart:core'];
 
   final _imports = <String, int>{};
+  final _usedAliases = <int>{};
 
   String? _url;
 
@@ -21,7 +22,14 @@ class HashedAllocator implements Allocator {
     return '_i${_imports.putIfAbsent(_url!, _hashedUrl)}.$symbol';
   }
 
-  int _hashedUrl() => _url.hashCode / 1000000 ~/ 1;
+  int _hashedUrl() {
+    var alias = _url.hashCode / 1000000 ~/ 1;
+    while (!_usedAliases.add(alias)) {
+      alias++;
+    }
+
+    return alias;
+  }
 
   @override
   Iterable<Directive> get imports =>

--- a/injectable_generator/test/code_builder/allocator_test.dart
+++ b/injectable_generator/test/code_builder/allocator_test.dart
@@ -1,0 +1,61 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:injectable_generator/code_builder/allocator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HashedAllocator test group', () {
+    test('Same url should always get the same alias', () {
+      final allocator = HashedAllocator();
+      const url = 'package:example/services/service.dart';
+      final first = allocator.allocate(refer('ServiceA', url));
+      final second = allocator.allocate(refer('ServiceB', url));
+      expect(_aliasOf(first), _aliasOf(second));
+    });
+
+    test('Urls with colliding hashes should get different aliases', () {
+      // find two urls that fall into the same hash bucket
+      final buckets = <int, String>{};
+      String? firstUrl, secondUrl;
+      for (var i = 0; firstUrl == null; i++) {
+        final url = 'package:example/feature_$i/service.dart';
+        final bucket = url.hashCode / 1000000 ~/ 1;
+        final existing = buckets[bucket];
+        if (existing != null) {
+          firstUrl = existing;
+          secondUrl = url;
+        } else {
+          buckets[bucket] = url;
+        }
+      }
+
+      final allocator = HashedAllocator();
+      final first = allocator.allocate(refer('Service', firstUrl));
+      final second = allocator.allocate(refer('Service', secondUrl!));
+      expect(_aliasOf(first), isNot(_aliasOf(second)));
+    });
+
+    test('Import directives should match allocated aliases', () {
+      final allocator = HashedAllocator();
+      final allocated = {
+        for (final url in [
+          'package:example/a.dart',
+          'package:example/b.dart',
+          'package:example/c.dart',
+        ])
+          url: _aliasOf(allocator.allocate(refer('Service', url))),
+      };
+      final directives = {
+        for (final import in allocator.imports) import.url: import.as,
+      };
+      expect(directives, allocated);
+    });
+
+    test('dart:core references should not be prefixed', () {
+      final allocator = HashedAllocator();
+      expect(allocator.allocate(refer('String', 'dart:core')), 'String');
+      expect(allocator.imports, isEmpty);
+    });
+  });
+}
+
+String _aliasOf(String allocated) => allocated.split('.').first;


### PR DESCRIPTION
Fixes #530

`HashedAllocator` derives import prefixes from `url.hashCode / 1000000 ~/ 1`, leaving only ~1074 possible values with no collision handling. When two registered classes share the same name and their file paths hash to the same value, the generated config gets two imports sharing one prefix and fails to compile.

The fix keeps the hash but bumps to the next free number on collision. Also added tests covering the collision case and alias stability.